### PR TITLE
Allow '+' in version tags

### DIFF
--- a/semver.js
+++ b/semver.js
@@ -8,7 +8,7 @@ var semver = "\\s*[v=]*\\s*([0-9]+)"                // major
            + "\\.([0-9]+)"                  // minor
            + "\\.([0-9]+)"                  // patch
            + "(-[0-9]+-?)?"                 // build
-           + "([a-zA-Z-][a-zA-Z0-9-\.:]*)?" // tag
+           + "([a-zA-Z-+][a-zA-Z0-9-\.:]*)?" // tag
   , exprComparator = "^((<|>)?=?)\s*("+semver+")$|^$"
   , xRangePlain = "[v=]*([0-9]+|x|X|\\*)"
                 + "(?:\\.([0-9]+|x|X|\\*)"

--- a/test.js
+++ b/test.js
@@ -41,6 +41,7 @@ test("\ncomparison tests", function (t) {
   , ["1.2.3-5", "1.2.3-5-foo"]
   , ["1.2.3-5", "1.2.3-4"]
   , ["1.2.3-5-foo", "1.2.3-5-Foo"]
+  , ["3.0.0", "2.7.2+"]
   ].forEach(function (v) {
     var v0 = v[0]
       , v1 = v[1]


### PR DESCRIPTION
Hi,

Deploying onto an ubuntu 11 image in Amazon EC2 - python version reported there is 2.7.2+, which semver doesn't compare correctly. This request fixes that problem.
