### PR TITLE
CLI Tool - Call fail on no valid versions

### DIFF
--- a/bin/semver
+++ b/bin/semver
@@ -33,6 +33,7 @@ function main () {
   }
 
   versions = versions.filter(semver.valid)
+  if (!versions.length) return fail()
   for (var i = 0, l = range.length; i < l ; i ++) {
     versions = versions.filter(function (v) {
       return semver.satisfies(v, range[i])


### PR DESCRIPTION
Return status code 1 even when no valid versions are passed. Allows the semver binary to be used for quick validation checking in shell scripts.

Example:

``` sh
$ semver -v abc1.2.3 ; echo $? #=> 1
```
