### PR TITLE
Drop zeroed build number

### DIFF
--- a/semver.js
+++ b/semver.js
@@ -298,7 +298,8 @@ function inc (version, release) {
     if (num(version[i]) !== -1) version[i] = "0"
   }
 
-  if (version[4]) version[4] = "-" + version[4]
+  if (version[4] === "0") version[4] = ""
+  else if (version[4]) version[4] = "-" + version[4]
   version[5] = ""
 
   return stringify(version)


### PR DESCRIPTION
I dont see a reason to keep a "0" build number when you increment a patch or higher. Keeps the version cleaner especially when you use "npm version" before a release.
### Desired Result using 1.2.3-4

Previously
`npm version patch` returned `1.2.4-0`

Now
`npm version patch` returns `1.2.4`
