### PR TITLE
Git-ignore npm-installed node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ semver.min.js
 semver.min.js.gz
 semver.browser.js
 semver.browser.js.gz
+/node_modules


### PR DESCRIPTION
Without this tiny change, projects using semver as a Git submodule (any other way?) always get this message:

``` bash
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#   (commit or discard the untracked or modified content in submodules)
#
#   modified:   node_modules/semver (untracked content)
#
```
