### PR TITLE
AMD compatibility

### DIFF
--- a/semver.js
+++ b/semver.js
@@ -1,6 +1,8 @@
 // export the class if we are in a Node-like system.
 if (typeof module === 'object' && module.exports === exports)
   exports = module.exports = SemVer;
+else if (typeof exports === 'undefined')
+  exports = {};
 
 // The debug function is excluded entirely from the minified version.
 /* nomin */ var debug;


### PR DESCRIPTION
If exports is not defined, the AMD compatibility breaks.

Ideally, everything would be wrapped in a scoped function for the `exports`, but this simple fix will at least make it work without changing the overall code structure. The leaking `export` global for AMD is certainly not ideal, but I don't see it causing any real world problems.
