### PR TITLE
Allow more semver 1.0 behavior if loose is true

### DIFF
--- a/semver.js
+++ b/semver.js
@@ -803,7 +803,7 @@ function replaceXRange(comp, loose) {
           m = 0;
           p = 0;
         } else if (xp) {
-          m = +m + 1;
+          !loose && (m = +m + 1);
           p = 0;
         }
       }


### PR DESCRIPTION
A lot of npm users lately are having an issue with no the no valid install targets error due to the semver 2.0 stuff. This strictness was reduced for some cases by https://github.com/isaacs/npm/commit/36a412d0eb065cdd1e916f6b001c098ff5c7efc3, but is still causing an issue for a lot of people due to the following change (which isn't affected by allowing loose semver currently):

``` javascript
// 1.0

semver.satisfies('2.1.0', '>2.x.x') // true

// 2.0

semver.satisfies('2.1.0', '>2.x.x') // false
```

It would be nice if we could allow this for the time being to reduce the amount of npm issues caused by semver 2.0 until we think of a better way to introduce it to the npm user base.
