### PR TITLE
satisfying functions with “stableOnly” flag, backward compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ strings that they parse.
 ### Ranges
 
 * validRange(range): Return the valid range or null if it's not valid
-* satisfies(version, range): Return true if the version satisfies the
+* satisfies(version, range, stableOnly): Return true if the version satisfies the
   range.
-* maxSatisfying(versions, range): Return the highest version in the list
+* maxSatisfying(versions, range, stableOnly): Return the highest version in the list
   that satisfies the range, or null if none of them do.
 * gtr(version, range): Return true if version is greater than all the
   versions possible in the range.

--- a/semver.js
+++ b/semver.js
@@ -879,8 +879,10 @@ function hyphenReplace($0,
 
 
 // if ANY of the sets match ALL of its comparators, then pass
-Range.prototype.test = function(version) {
+Range.prototype.test = function(version, stableOnly) {
   if (!version)
+    return false;
+  if(stableOnly && version.indexOf('-')> -1)
     return false;
   for (var i = 0; i < this.set.length; i++) {
     if (testSet(this.set[i], version))
@@ -898,19 +900,19 @@ function testSet(set, version) {
 }
 
 exports.satisfies = satisfies;
-function satisfies(version, range, loose) {
+function satisfies(version, range, loose, stableOnly) {
   try {
     range = new Range(range, loose);
   } catch (er) {
     return false;
   }
-  return range.test(version);
+  return range.test(version, stableOnly);
 }
 
 exports.maxSatisfying = maxSatisfying;
-function maxSatisfying(versions, range, loose) {
+function maxSatisfying(versions, range, loose, stableOnly) {
   return versions.filter(function(version) {
-    return satisfies(version, range, loose);
+    return satisfies(version, range, loose, stableOnly);
   }).sort(function(a, b) {
     return rcompare(a, b, loose);
   })[0] || null;

--- a/test/stable.js
+++ b/test/stable.js
@@ -1,0 +1,27 @@
+var tap = require('tap');
+var test = tap.test;
+var semver = require('../semver.js');
+var ltr = semver.ltr;
+
+
+test('\nmax satisfying', function(t) {
+  [
+   [['1.2.3', '1.2.4-alpha'], '1.2', '1.2.4-alpha', undefined],
+   [['1.2.3', '1.2.4-alpha'], '1.2', '1.2.3', undefined, true],
+   [['1.2.4-beta', '1.2.3'], '1.2', '1.2.4-beta', undefined],
+   [['1.2.4-beta', '1.2.3'], '1.2', '1.2.3', undefined, true],
+   [['1.2.3', '1.2.4', '1.2.5', '1.2.6-0'], '~1.2.3', '1.2.6-0', undefined],
+   [['1.2.3', '1.2.4', '1.2.5', '1.2.6-0'], '~1.2.3', '1.2.5', undefined, true],
+   [['1.2.3', '1.2.4', '1.2.5', '1.2.6-0', '2.0.0-rc', '2.0.0', '2.1.0-rc'], '*', '2.1.0-rc', undefined],
+   [['1.2.3', '1.2.4', '1.2.5', '1.2.6-0', '2.0.0-rc', '2.0.0', '2.1.0-rc'], '*', '2.0.0', undefined, true]
+  ].forEach(function(v) {
+      var versions = v[0];
+      var range = v[1];
+      var expect = v[2];
+      var loose = v[3];
+      var stableOnly = v[4];
+      var actual = semver.maxSatisfying(versions, range, loose, stableOnly);
+      t.equal(actual, expect);
+    });
+  t.end();
+});


### PR DESCRIPTION
I know this "flag" is not supported by semver spec 2.0, but I find myself really need this feature. If anyone is also interested, we may open a discussion for semver operator for this flag, for example:

```
"node-semver": "$*"
"npm": "$1.1.x"
```
