### PR TITLE
Add tests for clean method.

### DIFF
--- a/test/clean.js
+++ b/test/clean.js
@@ -1,0 +1,25 @@
+var tap = require('tap');
+var test = tap.test;
+var semver = require('../semver.js');
+var clean = semver.clean;
+
+test('\nclean tests', function(t) {
+	// [range, version]
+	// Version should be detectable despite extra characters
+	[
+		['1.2.3', '1.2.3'],
+		[' 1.2.3 ', '1.2.3'],
+		[' 1.2.3-4 ', '1.2.3-4'],
+		[' 1.2.3-pre ', '1.2.3-pre'],
+		['  =v1.2.3   ', '1.2.3'],
+		['v1.2.3', '1.2.3'],
+		[' v1.2.3 ', '1.2.3'],
+		['\t1.2.3', '1.2.3']
+	].forEach(function(tuple) {
+			var range = tuple[0];
+			var version = tuple[1];
+			var msg = 'clean(' + range + ') = ' + version;
+			t.equal(clean(range), version, msg);
+		});
+	t.end();
+});


### PR DESCRIPTION
Thanks for explaining in #58 and #59 about `.clean()`, but it still doesn't seem to work as intended.

I added a test file to make sure `.clean()` works as intended, and to serve as documentation. I didn't use ranges this time so it should be correct.

Only 2/8 pass. Output:

```
ok 1 clean(1.2.3) = 1.2.3
not ok 2 clean( 1.2.3 ) = 1.2.3
not ok 3 clean( 1.2.3-4 ) = 1.2.3-4
not ok 4 clean( 1.2.3-pre ) = 1.2.3-pre
not ok 5 clean(  =v1.2.3   ) = 1.2.3
ok 6 clean(v1.2.3) = 1.2.3
not ok 7 clean( v1.2.3 ) = 1.2.3
not ok 8 clean( 1.2.3) = 1.2.3
```

Test 5, `=v1.2.3`, is from the readme.
