### PR TITLE
Add tests and fix for prepatch

### DIFF
--- a/semver.js
+++ b/semver.js
@@ -366,6 +366,9 @@ SemVer.prototype.inc = function(release) {
       this.inc('pre');
       break;
     case 'prepatch':
+      // If this is already a prerelease, it will bump to the next version
+      if (this.prerelease.length > 0)
+        this.inc('patch');
       this.inc('patch');
       this.inc('pre');
       break;

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var tap = require('tap');
 var test = tap.test;
 var semver = require('../semver.js');
@@ -327,10 +329,12 @@ test('\nincrement versions test', function(t) {
     ['1.2.3-alpha.9.beta', 'prerelease', '1.2.3-alpha.10.beta'],
     ['1.2.3-alpha.10.beta', 'prerelease', '1.2.3-alpha.11.beta'],
     ['1.2.3-alpha.11.beta', 'prerelease', '1.2.3-alpha.12.beta'],
+    ['1.2.0', 'prepatch', '1.2.1-0'],
+    ['1.2.0-1', 'prepatch', '1.2.1-0'],
     ['1.2.0', 'preminor', '1.3.0-0'],
+    ['1.2.0-1', 'preminor', '1.3.0-0'],
     ['1.2.0', 'premajor', '2.0.0-0'],
-    ['1.2.0', 'preminor', '1.3.0-0'],
-    ['1.2.0', 'premajor', '2.0.0-0']
+    ['1.2.0-1', 'premajor', '2.0.0-0']
 
 
   ].forEach(function(v) {


### PR DESCRIPTION
Adds tests for prepatch, removes duplicate preminor and premajor tests.
Adds fix for prepatch run on a prerelease not bumping to the next patch
version similar to preminor and premajor.

Fixes #86
