### PR TITLE
(clean) added test cases for ranges

### DIFF
--- a/test/clean.js
+++ b/test/clean.js
@@ -14,7 +14,11 @@ test('\nclean tests', function(t) {
 		['  =v1.2.3   ', '1.2.3'],
 		['v1.2.3', '1.2.3'],
 		[' v1.2.3 ', '1.2.3'],
-		['\t1.2.3', '1.2.3']
+		['\t1.2.3', '1.2.3'],
+		['>1.2.3', null],
+		['~1.2.3', null],
+		['<=1.2.3', null],
+		['1.2.x', null]
 	].forEach(function(tuple) {
 			var range = tuple[0];
 			var version = tuple[1];


### PR DESCRIPTION
On first glance I was confused why `clean('~1.2.3')` wasn't working and had to do a search.

I added test cases to reinforce the way `clean` works

See item #58
