### PR TITLE
Fix for amdefine@0.1.0

### DIFF
--- a/semver.js
+++ b/semver.js
@@ -1147,5 +1147,5 @@ function outside(version, range, hilo, loose) {
 }
 
 // Use the define() function if we're in AMD land
-if (typeof define === 'function' && define.amd)
-  define(exports);
+//if (typeof define === 'function' && define.amd)
+//  define(exports);


### PR DESCRIPTION
last two lines were causing described error in nodejs with amdefine@0.1.0

```
/.../node_modules/semver/semver.js:262
    throw new TypeError('Invalid Version: ' + version);
          ^
TypeError: Invalid Version: function amdRequire(deps, callback) {
            if (typeof deps === 'string') {
                //Synchronous, single module require('')
                return stringRequire(systemRequire, exports, module, deps, relId);
            } else {
                //Array of dependencies with a callback.

                //Convert the dependencies to modules.
                deps = deps.map(function (depName) {
                    return stringRequire(systemRequire, exports, module, depName, relId);
                });

                //Wait for next tick to call back the require call.
                process.nextTick(function () {
                    callback.apply(null, deps);
                });
            }
        }
    at Function.SemVer (/.../node_modules/semver/semver.js:262:11)
    at runFactory (/.../node_modules/amdefine/amdefine.js:181:30)
    at define (/.../node_modules/amdefine/amdefine.js:275:13)
    at Object.<anonymous> (/.../node_modules/semver/semver.js:1151:3)
    at Module._compile (module.js:456:26)
    at Object.intercept [as .js] (/.../node_modules/amdefine/intercept.js:29:12)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
```