### PR TITLE
Make "*" not satisfied by prerelease versions

### DIFF
--- a/semver.js
+++ b/semver.js
@@ -1170,6 +1170,9 @@ function outside(version, range, hilo, loose) {
     var low = null;
 
     comparators.forEach(function(comparator) {
+      if (comparator.semver === ANY) {
+        comparator = new Comparator('>=0.0.0')
+      }
       high = high || comparator;
       low = low || comparator;
       if (gtfn(comparator.semver, high.semver, loose)) {

--- a/semver.js
+++ b/semver.js
@@ -1070,7 +1070,7 @@ function testSet(set, version) {
     for (var i = 0; i < set.length; i++) {
       debug(set[i].semver);
       if (set[i].semver === ANY)
-        return true;
+        continue;
 
       if (set[i].semver.prerelease.length > 0) {
         var allowed = set[i].semver;

--- a/test/index.js
+++ b/test/index.js
@@ -148,7 +148,7 @@ test('\nrange tests', function(t) {
     ['>=*', '0.2.4'],
     ['', '1.0.0'],
     ['*', '1.2.3'],
-    ['*', 'v1.2.3-foo', true],
+    ['*', 'v1.2.3', true],
     ['>=1.0.0', '1.0.0'],
     ['>=1.0.0', '1.0.1'],
     ['>=1.0.0', '1.1.0'],
@@ -301,6 +301,7 @@ test('\nnegative range tests', function(t) {
     ['^1.2.3', '2.0.0-alpha'],
     ['^1.2.3', '1.2.2'],
     ['^1.2', '1.1.9'],
+    ['*', 'v1.2.3-foo', true],
     // invalid ranges never satisfied!
     ['blerg', '1.2.3'],
     ['git+https://user:password0123@github.com/foo', '123.0.0', true],

--- a/test/ltr.js
+++ b/test/ltr.js
@@ -70,7 +70,8 @@ test('\nltr tests', function(t) {
     ['^1', '1.0.0-0'],
     ['>=0.7.x', '0.7.0-asdf'],
     ['1', '1.0.0beta', true],
-    ['>=0.7.x', '0.6.2']
+    ['>=0.7.x', '0.6.2'],
+    ['>1.2.3', '1.3.0-alpha']
   ].forEach(function(tuple) {
     var range = tuple[0];
     var version = tuple[1];
@@ -83,7 +84,7 @@ test('\nltr tests', function(t) {
 
 test('\nnegative ltr tests', function(t) {
   // [range, version, loose]
-  // Version should NOT be greater than range
+  // Version should NOT be less than range
   [
     ['~ 1.0', '1.1.0'],
     ['~0.6.1-1', '0.6.1-1'],
@@ -93,7 +94,6 @@ test('\nnegative ltr tests', function(t) {
     ['>=*', '0.2.4'],
     ['', '1.0.0', true],
     ['*', '1.2.3'],
-    ['*', 'v1.2.3-foo'],
     ['>=1.0.0', '1.0.0'],
     ['>=1.0.0', '1.0.1'],
     ['>=1.0.0', '1.1.0'],


### PR DESCRIPTION
Fixes #123 

In the process of fixing this, I found that `ltr('>=0.0.0', '1.2.3-foo') === true`. I'm not sure how to sensibly handle this case, but I documented the behaviour with a new test.