### PR TITLE
Add prerelease function

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ strings that they parse.
     same as `prepatch`. It increments the patch version, then makes a
     prerelease. If the input version is already a prerelease it simply
     increments it.
+* `prerelease(v)`: Returns an array of prerelease components, or null
+  if none exist. Example: `prerelease('1.2.3-alpha.1') -> ['alpha', 1]`
 * `major(v)`: Return the major version number.
 * `minor(v)`: Return the minor version number.
 * `patch(v)`: Return the patch version number.

--- a/semver.js
+++ b/semver.js
@@ -1186,3 +1186,9 @@ function outside(version, range, hilo, loose) {
   }
   return true;
 }
+
+exports.prerelease = prerelease;
+function prerelease(version, loose) {
+  var parsed = parse(version, loose);
+  return (parsed && parsed.prerelease.length) ? parsed.prerelease : null;
+}

--- a/test/prerelease.js
+++ b/test/prerelease.js
@@ -1,0 +1,26 @@
+var tap = require('tap');
+var test = tap.test;
+var semver = require('../semver.js');
+var prerelease = semver.prerelease;
+
+test('\nprerelease', function(t) {
+  // [prereleaseParts, version, loose]
+  [
+    [['alpha', 1], '1.2.2-alpha.1'],
+    [[1], '0.6.1-1'],
+    [['beta', 2], '1.0.0-beta.2'],
+    [['pre'], 'v0.5.4-pre'],
+    [['alpha', 1], '1.2.2-alpha.1', false],
+    [['beta'], '0.6.1beta', true],
+    [null, '1.0.0', true],
+    [null, '~2.0.0-alpha.1', false],
+    [null, 'invalid version'],
+  ].forEach(function(tuple) {
+    var expected = tuple[0];
+    var version = tuple[1];
+    var loose = tuple[2];
+    var msg = 'prerelease(' + version + ')';
+    t.same(prerelease(version, loose), expected, msg);
+  });
+  t.end();
+});


### PR DESCRIPTION
Implements the functionality discussed in #133.
`prerelease('1.2.3-alpha.1') -> ['alpha', 1]`
`prerelease('1.2.3') -> null`