### PR TITLE
Fix usage of semver module in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ semver(1) -- The semantic versioner for npm
 ## Usage
 
     $ npm install semver
+    $ node
+    var semver = require('semver')
 
     semver.valid('1.2.3') // '1.2.3'
     semver.valid('a.b.c') // null


### PR DESCRIPTION
Previously the docs displayed only installing the `semver` module and not going into a node shell or requiring the module before displaying examples.

I think this update makes it a little clearer that `semver` is a standard node module and it is used internally in `npm`.

First made change over at https://github.com/npm/npm/pull/10765 but was pointed in the direction of this repo as the source of those docs.