### PR TITLE
Fix Backus-Naur "nr" expansion (previous expansion forbade 1 to 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ simple     ::= primitive | partial | tilde | caret
 primitive  ::= ( '<' | '>' | '>=' | '<=' | '=' | ) partial
 partial    ::= xr ( '.' xr ( '.' xr qualifier ? )? )?
 xr         ::= 'x' | 'X' | '*' | nr
-nr         ::= '0' | ['1'-'9']['0'-'9']+
+nr         ::= '0' | ['1'-'9'] ( ['0'-'9'] ) *
 tilde      ::= '~' partial
 caret      ::= '^' partial
 qualifier  ::= ( '-' pre )? ( '+' build )?

--- a/range.bnf
+++ b/range.bnf
@@ -6,7 +6,7 @@ simple     ::= primitive | partial | tilde | caret
 primitive  ::= ( '<' | '>' | '>=' | '<=' | '=' | ) partial
 partial    ::= xr ( '.' xr ( '.' xr qualifier ? )? )?
 xr         ::= 'x' | 'X' | '*' | nr
-nr         ::= '0' | ['1'-'9']['0'-'9']+
+nr         ::= '0' | ['1'-'9'] ( ['0'-'9'] ) *
 tilde      ::= '~' partial
 caret      ::= '^' partial
 qualifier  ::= ( '-' pre )? ( '+' build )?


### PR DESCRIPTION
The old BNF expands "nr"s as:
- 0, or
- 1-9 followed by **one** or more digit from 0-9

i.e. excludes non-zero single-digit numbers. It should be:
- 0, or
- 1-9 followed by **zero** or more digit from 0-9