### PR TITLE
Exclude tests from publication

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-node_modules/
-coverage/
-.nyc_output/
-nyc_output/

--- a/package.json
+++ b/package.json
@@ -13,5 +13,10 @@
   "repository": "https://github.com/npm/node-semver",
   "bin": {
     "semver": "./bin/semver"
-  }
+  },
+  "files": [
+    "bin",
+    "range.bnf",
+    "semver.js"
+  ]
 }


### PR DESCRIPTION
This came up recently in https://github.com/yargs/yargs/issues/468#issuecomment-206442013.

Would be nice to trim the package size a bit by excluding tests, and I prefer whitelisting files in `package.json` over blacklisting files in `.npmignore`, but I can be persuaded otherwise.

Here is the result of `npm pack` before and after this change:

```
# BEFORE
x package/package.json
x package/.npmignore
x package/README.md
x package/LICENSE
x package/semver.js
x package/bin/semver
x package/.travis.yml
x package/range.bnf
x package/test/big-numbers.js
x package/test/clean.js
x package/test/gtr.js
x package/test/index.js
x package/test/ltr.js
x package/test/major-minor-patch.js

# AFTER
x package/package.json
x package/README.md
x package/LICENSE
x package/semver.js
x package/bin/semver
x package/range.bnf
```