### PR TITLE
Allow piping into semver to read versions

### DIFF
--- a/bin/semver
+++ b/bin/semver
@@ -16,10 +16,29 @@ var argv = process.argv.slice(2)
   , semver = require("../semver")
   , reverse = false
 
-main()
+preMain()
 
-function main () {
-  if (!argv.length) return help()
+function preMain() {
+  if (!process.stdin.isTTY) {
+    process.stdin.setEncoding('utf8');
+
+    process.stdin.on('readable', function() {
+      var chunk = process.stdin.read();
+      if (chunk !== null) {
+        versions = versions.concat(chunk.split(/\s/));
+      }
+    });
+
+    process.stdin.on('end', () => {
+      main(versions.length !== 0);
+    });
+  } else {
+    main(false);
+  }
+}
+
+function main (piped) {
+  if (!argv.length && !piped) return help()
   while (argv.length) {
     var a = argv.shift()
     var i = a.indexOf('=')
@@ -56,6 +75,7 @@ function main () {
         break
       case "-h": case "--help": case "-?":
         return help()
+        break
       default:
         versions.push(a)
         break

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,22 +1,39 @@
-var test = require('tap').test
-var exec = require('child_process').exec
+var test = require('tap').test;
+var execSync = require('child_process').execSync
+var exec = require('child_process').exec;
 
 test('the command line using pipes or arguments produces the same output', function (t) {
-  t.plan(6);
-  var bin = 'node ./bin/semver ';
-  [[bin+'-i 1.0.0', 'echo 1.0.0 | '+bin+'-i'],
-    [bin+'-i major 1.0.0', 'echo 1.0.0 | '+bin+'-i major'],
-    [bin+'-i prerelease 1.0.0', 'echo 1.0.0 | '+bin+'-i prerelease'],
-    [bin+'-i preminor 1.0.0', 'echo 1.0.0 | '+bin+'-i preminor'],
-    [bin+'-i prepatch --preid alpha 1.0.0', 'echo 1.0.0 | '+bin+'-i prepatch --preid alpha'],
-    [bin+'-r \\>1.0.0 0.8.0 1.1.1', 'echo 0.8.0 1.1.1 | '+bin+'-r \\>1.0.0']
-  ].forEach(function(tab) {
-    exec(tab[0], function(error, stdout, stderr) {
-      var resCli = stdout + stderr;
-      exec(tab[1], function(error, stdout, stderr) {
-        var resPipe = stdout + stderr;
-        t.assert(resCli === resPipe);
+  if (execSync === undefined) {
+    t.plan(6);
+    var bin = 'node ./bin/semver ';
+    [[bin+'-i 1.0.0', 'echo 1.0.0 | '+bin+'-i'],
+      [bin+'-i major 1.0.0', 'echo 1.0.0 | '+bin+'-i major'],
+      [bin+'-i prerelease 1.0.0', 'echo 1.0.0 | '+bin+'-i prerelease'],
+      [bin+'-i preminor 1.0.0', 'echo 1.0.0 | '+bin+'-i preminor'],
+      [bin+'-i prepatch --preid alpha 1.0.0', 'echo 1.0.0 | '+bin+'-i prepatch --preid alpha'],
+      [bin+'-r \\>1.0.0 0.8.0 1.1.1', 'echo 0.8.0 1.1.1 | '+bin+'-r \\>1.0.0']
+    ].forEach(function(tab) {
+      exec(tab[0], function(error, stdout, stderr) {
+        var resCli = stdout + stderr;
+        exec(tab[1], function(error, stdout, stderr) {
+          var resPipe = stdout + stderr;
+          t.assert(resCli === resPipe);
+        });
       });
     });
-  });
+  } else {
+    var bin = 'node ./bin/semver ';
+    [[bin+'-i 1.0.0', 'echo 1.0.0 | '+bin+'-i'],
+      [bin+'-i major 1.0.0', 'echo 1.0.0 | '+bin+'-i major'],
+      [bin+'-i prerelease 1.0.0', 'echo 1.0.0 | '+bin+'-i prerelease'],
+      [bin+'-i preminor 1.0.0', 'echo 1.0.0 | '+bin+'-i preminor'],
+      [bin+'-i prepatch --preid alpha 1.0.0', 'echo 1.0.0 | '+bin+'-i prepatch --preid alpha'],
+      [bin+'-r \\>1.0.0 0.8.0 1.1.1', 'echo 0.8.0 1.1.1 | '+bin+'-r \\>1.0.0']
+    ].forEach(function(tab) {
+       var resCli = execSync(tab[0]);
+       var resPipe = execSync(tab[1]);
+       t.assert(resCli.equals(resPipe));
+    });
+    t.end();
+  }
 })

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,18 @@
+var test = require('tap').test
+var execSync = require('child_process').execSync
+
+test('the command line using pipes or arguments produces the same output', function (t) {
+  var exec = 'node ./bin/semver ';
+  [[exec+'-i 1.0.0', 'echo 1.0.0 | '+exec+'-i'],
+    [exec+'-i major 1.0.0', 'echo 1.0.0 | '+exec+'-i major'],
+    [exec+'-i prerelease 1.0.0', 'echo 1.0.0 | '+exec+'-i prerelease'],
+    [exec+'-i preminor 1.0.0', 'echo 1.0.0 | '+exec+'-i preminor'],
+    [exec+'-i prepatch --preid alpha 1.0.0', 'echo 1.0.0 | '+exec+'-i prepatch --preid alpha'],
+    [exec+'-r \\>1.0.0 0.8.0 1.1.1', 'echo 0.8.0 1.1.1 | '+exec+'-r \\>1.0.0']
+  ].forEach(function(tab) {
+    var resCli = execSync(tab[0]);
+    var resPipe = execSync(tab[1]);
+    t.assert(resCli.equals(resPipe));
+  });
+  t.end()
+})

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,18 +1,22 @@
 var test = require('tap').test
-var execSync = require('child_process').execSync
+var exec = require('child_process').exec
 
 test('the command line using pipes or arguments produces the same output', function (t) {
-  var exec = 'node ./bin/semver ';
-  [[exec+'-i 1.0.0', 'echo 1.0.0 | '+exec+'-i'],
-    [exec+'-i major 1.0.0', 'echo 1.0.0 | '+exec+'-i major'],
-    [exec+'-i prerelease 1.0.0', 'echo 1.0.0 | '+exec+'-i prerelease'],
-    [exec+'-i preminor 1.0.0', 'echo 1.0.0 | '+exec+'-i preminor'],
-    [exec+'-i prepatch --preid alpha 1.0.0', 'echo 1.0.0 | '+exec+'-i prepatch --preid alpha'],
-    [exec+'-r \\>1.0.0 0.8.0 1.1.1', 'echo 0.8.0 1.1.1 | '+exec+'-r \\>1.0.0']
+  t.plan(6);
+  var bin = 'node ./bin/semver ';
+  [[bin+'-i 1.0.0', 'echo 1.0.0 | '+bin+'-i'],
+    [bin+'-i major 1.0.0', 'echo 1.0.0 | '+bin+'-i major'],
+    [bin+'-i prerelease 1.0.0', 'echo 1.0.0 | '+bin+'-i prerelease'],
+    [bin+'-i preminor 1.0.0', 'echo 1.0.0 | '+bin+'-i preminor'],
+    [bin+'-i prepatch --preid alpha 1.0.0', 'echo 1.0.0 | '+bin+'-i prepatch --preid alpha'],
+    [bin+'-r \\>1.0.0 0.8.0 1.1.1', 'echo 0.8.0 1.1.1 | '+bin+'-r \\>1.0.0']
   ].forEach(function(tab) {
-    var resCli = execSync(tab[0]);
-    var resPipe = execSync(tab[1]);
-    t.assert(resCli.equals(resPipe));
+    exec(tab[0], function(error, stdout, stderr) {
+      var resCli = stdout + stderr;
+      exec(tab[1], function(error, stdout, stderr) {
+        var resPipe = stdout + stderr;
+        t.assert(resCli === resPipe);
+      });
+    });
   });
-  t.end()
 })

--- a/test/cli.js
+++ b/test/cli.js
@@ -3,7 +3,7 @@ var execSync = require('child_process').execSync
 var exec = require('child_process').exec;
 
 test('the command line using pipes or arguments produces the same output', function (t) {
-  if (execSync === undefined) {
+  if (process.version.substring(0,5) === 'v0.10' || process.version.substring(0,5) === 'v0.12') {
     t.plan(6);
     var bin = 'node ./bin/semver ';
     [[bin+'-i 1.0.0', 'echo 1.0.0 | '+bin+'-i'],


### PR DESCRIPTION
This is a patch for #149.

Before entering the main, we check if the process is piped. If so then we fill the `versions` array and then we launch the main. In order to fill the array, we split on spaces.

NB : versions can be accepted both from the pipe and as arguments.
For example `echo 1.0.0 | semver -r '>=1' 1.1.1` is accepted.

NB2 : testing relies on comparing the output of the version without piping, and the version with piping.
