### PR TITLE
add minSatisfying

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ strings that they parse.
   range.
 * `maxSatisfying(versions, range)`: Return the highest version in the list
   that satisfies the range, or `null` if none of them do.
+* `minSatisfying(versions, range)`: Return the lowest version in the list
+  that satisfies the range, or `null` if none of them do.
 * `gtr(version, range)`: Return `true` if version is greater than all the
   versions possible in the range.
 * `ltr(version, range)`: Return `true` if version is less than all the

--- a/semver.js
+++ b/semver.js
@@ -1094,6 +1094,15 @@ function maxSatisfying(versions, range, loose) {
   })[0] || null;
 }
 
+exports.minSatisfying = minSatisfying;
+function minSatisfying(versions, range, loose) {
+  return versions.filter(function(version) {
+    return satisfies(version, range, loose);
+  }).sort(function(a, b) {
+    return compare(a, b, loose);
+  })[0] || null;
+}
+
 exports.validRange = validRange;
 function validRange(range, loose) {
   try {

--- a/test/index.js
+++ b/test/index.js
@@ -696,3 +696,19 @@ test('\nmax satisfying', function(t) {
   });
   t.end();
 });
+
+test('\nmin satisfying', function(t) {
+  [[['1.2.3', '1.2.4'], '1.2', '1.2.3'],
+    [['1.2.4', '1.2.3'], '1.2', '1.2.3'],
+    [['1.2.3', '1.2.4', '1.2.5', '1.2.6'], '~1.2.3', '1.2.3'],
+    [['1.1.0', '1.2.0', '1.2.1', '1.3.0', '2.0.0b1', '2.0.0b2', '2.0.0b3', '2.0.0', '2.1.0'], '~2.0.0', '2.0.0', true]
+  ].forEach(function(v) {
+    var versions = v[0];
+    var range = v[1];
+    var expect = v[2];
+    var loose = v[3];
+    var actual = semver.minSatisfying(versions, range, loose);
+    t.equal(actual, expect);
+  });
+  t.end();
+});


### PR DESCRIPTION
This adds the function `minSatisfying` which is a mirror of `maxSatisfying` i.e. it returns the *lowest* version in the range that satisfies the given range.  As you can see it's an exact copy of `minSatisfying` that simply reverses the sort order being passed to `.filter`

The need for this arose from trying to resolve multiple security advisories that have semver ranges for which the problem has been fixed.  It is valuable to be able to distill the minimum version needed to satisfy each of those ranges, to (as much as possible) mitigate the potential impact that updates would cause.