### PR TITLE
Variable data

### DIFF
--- a/semver.js
+++ b/semver.js
@@ -568,6 +568,16 @@ function patch(a, loose) {
   return new SemVer(a, loose).patch;
 }
 
+exports.prerelease = prerelease;
+function prerelease(a, loose) {
+    return new SemVer(a, loose).prerelease.join('.');
+}
+
+exports.build = build;
+function build(a, loose) {
+    return new SemVer(a, loose).build.join('.');
+}
+
 exports.compare = compare;
 function compare(a, b, loose) {
   return new SemVer(a, loose).compare(b);

--- a/test/build-metadata.js
+++ b/test/build-metadata.js
@@ -1,0 +1,37 @@
+var tap = require('tap');
+var test = tap.test;
+var semver = require('../semver.js');
+
+test('\nbuild-metadata', function(t) {
+  // [metadata, version]
+  [
+    [['alpha', '1'], '1.2.2+alpha.1'],
+    [[1], '0.6.1+1'],
+    [['pre'], 'v0.5.4+pre'],
+    [['alpha', '1'], 'v1.2.2+alpha.1'],
+    [['abc'], '0.6.1-beta+abc'],
+    [[], '1.0.0'],
+    [[], '2.0.0-alpha.1'],
+  ].forEach(function(tuple) {
+    var expected = tuple[0];
+    var version = tuple[1];
+    var msg = 'build metadata(' + version + ')';
+    t.same(semver(version).build, expected, msg);
+  });
+  t.end();
+});
+
+test('\nformat', function(t) {
+  parseAndPrint = function(versionString) {
+    return semver(versionString).format();
+  };
+
+  [
+    '0.0.0',
+    '0.1.0+abc',
+    '1.0.0-beta+abc',
+  ].forEach(function(versionString) {
+    t.same(parseAndPrint(versionString), versionString);
+  });
+  t.end();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -712,3 +712,18 @@ test('\nmin satisfying', function(t) {
   });
   t.end();
 });
+
+test('\ndynamic variables', function(t) {
+  var versionString = '0.0.0';
+  var version = semver(versionString);
+  t.equal(version.major, 0);
+
+  version.major = 3;
+  t.equal(version.major, 3);
+  t.equal(version.format(), '3.0.0');
+
+  version.build.push('abc');
+  t.equal(version.build[0], 'abc');
+  t.equal(version.format(), '3.0.0+abc');
+  t.end();
+});


### PR DESCRIPTION
- Adds the capability to change variables and produce a semver string
- Fixes .format() (together with .version & .toString()) to include any build variable data if present 
- Stores any prefix data that was parsed out. (Note that as its not part of the semver spec it is not exported via toString() )
- Adds associated unit tests
