### PR TITLE
Add support for string representations of numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "bin",
     "range.bnf",
     "semver.js"
-  ]
+  ],
+  "dependencies": {
+    "number-strings": "^1.0.1"
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -52,22 +52,43 @@ test('\ncomparison tests', function(t) {
     ['1.2.3-a.b', '1.2.3-a'],
     ['1.2.3-a.b.c.10.d.5', '1.2.3-a.b.c.5.d.100'],
     ['1.2.3-r2', '1.2.3-r100'],
-    ['1.2.3-r100', '1.2.3-R2']
+    ['1.2.3-r100', '1.2.3-R2'],
+
+    ['zero point zero point zero', 'zero point zero point zero-foo', false, true],
+    ['zero point zero point one', 'zero point zero point zero', false, true],
+    ['one point zero point zero', 'zero point nine point nine', false, true],
+    ['zero point ten point zero', 'zero point nine point zero', false, true],
+    ['zero point ninety-nine point zero', 'zero point ten point zero', false, true],
+    ['two point zero point zero', 'one point two point three', false, true],
+    ['one point two point three', 'one point two point three-asdf', false, true],
+    ['one point two point three', 'one point two point three-4', false, true],
+    ['one point two point three', 'one point two point three-4-foo', false, true],
+    ['one point two point three-5-foo', 'one point two point three-5', false, true],
+    ['one point two point three-5', 'one point two point three-4', false, true],
+    ['one point two point three-5-foo', 'one point two point three-5-Foo', false, true],
+    ['three point zero point zero', 'two point seven point two+asdf', false, true],
+    ['one point two point three-a.10', 'one point two point three-a.5', false, true],
+    ['one point two point three-a.b', 'one point two point three-a.5', false, true],
+    ['one point two point three-a.b', 'one point two point three-a', false, true],
+    ['one point two point three-a.b.c.10.d.5', 'one point two point three-a.b.c.5.d.100', false, true],
+    ['one point two point three-r2', 'one point two point three-r100', false, true],
+    ['one point two point three-r100', 'one point two point three-R2', false, true]
   ].forEach(function(v) {
     var v0 = v[0];
     var v1 = v[1];
     var loose = v[2];
-    t.ok(gt(v0, v1, loose), "gt('" + v0 + "', '" + v1 + "')");
-    t.ok(lt(v1, v0, loose), "lt('" + v1 + "', '" + v0 + "')");
-    t.ok(!gt(v1, v0, loose), "!gt('" + v1 + "', '" + v0 + "')");
-    t.ok(!lt(v0, v1, loose), "!lt('" + v0 + "', '" + v1 + "')");
-    t.ok(eq(v0, v0, loose), "eq('" + v0 + "', '" + v0 + "')");
-    t.ok(eq(v1, v1, loose), "eq('" + v1 + "', '" + v1 + "')");
-    t.ok(neq(v0, v1, loose), "neq('" + v0 + "', '" + v1 + "')");
-    t.ok(cmp(v1, '==', v1, loose), "cmp('" + v1 + "' == '" + v1 + "')");
-    t.ok(cmp(v0, '>=', v1, loose), "cmp('" + v0 + "' >= '" + v1 + "')");
-    t.ok(cmp(v1, '<=', v0, loose), "cmp('" + v1 + "' <= '" + v0 + "')");
-    t.ok(cmp(v0, '!=', v1, loose), "cmp('" + v0 + "' != '" + v1 + "')");
+    var stringForm = v[3];
+    t.ok(gt(v0, v1, loose, stringForm), "gt('" + v0 + "', '" + v1 + "')");
+    t.ok(lt(v1, v0, loose, stringForm), "lt('" + v1 + "', '" + v0 + "')");
+    t.ok(!gt(v1, v0, loose, stringForm), "!gt('" + v1 + "', '" + v0 + "')");
+    t.ok(!lt(v0, v1, loose, stringForm), "!lt('" + v0 + "', '" + v1 + "')");
+    t.ok(eq(v0, v0, loose, stringForm), "eq('" + v0 + "', '" + v0 + "')");
+    t.ok(eq(v1, v1, loose, stringForm), "eq('" + v1 + "', '" + v1 + "')");
+    t.ok(neq(v0, v1, loose, stringForm), "neq('" + v0 + "', '" + v1 + "')");
+    t.ok(cmp(v1, '==', v1, loose, stringForm), "cmp('" + v1 + "' == '" + v1 + "')");
+    t.ok(cmp(v0, '>=', v1, loose, stringForm), "cmp('" + v0 + "' >= '" + v1 + "')");
+    t.ok(cmp(v1, '<=', v0, loose, stringForm), "cmp('" + v1 + "' <= '" + v0 + "')");
+    t.ok(cmp(v0, '!=', v1, loose, stringForm), "cmp('" + v0 + "' != '" + v1 + "')");
   });
   t.end();
 });
@@ -111,25 +132,31 @@ test('\nequality tests', function(t) {
     ['1.2.3+build', ' = 1.2.3+otherbuild', true],
     ['1.2.3-beta+build', '1.2.3-beta+otherbuild'],
     ['1.2.3+build', '1.2.3+otherbuild'],
-    ['  v1.2.3+build', '1.2.3+otherbuild']
+    ['  v1.2.3+build', '1.2.3+otherbuild'],
+    ['  v1.2.3+build', '1.2.3+otherbuild'],
+
+    ['one dot two dot three-beta+build', 'one dot two dot three-beta+otherbuild', false, true],
+    ['one dot two dot three+build', 'one dot two dot three+otherbuild', false, true],
+    ['  vone dot two dot three+build', 'one dot two dot three+otherbuild', false, true],
+    ['  vone dot two dot three+build', 'one dot two dot three+otherbuild', false, true]
   ].forEach(function(v) {
     var v0 = v[0];
     var v1 = v[1];
     var loose = v[2];
-    t.ok(eq(v0, v1, loose), "eq('" + v0 + "', '" + v1 + "')");
-    t.ok(!neq(v0, v1, loose), "!neq('" + v0 + "', '" + v1 + "')");
-    t.ok(cmp(v0, '==', v1, loose), 'cmp(' + v0 + '==' + v1 + ')');
-    t.ok(!cmp(v0, '!=', v1, loose), '!cmp(' + v0 + '!=' + v1 + ')');
-    t.ok(!cmp(v0, '===', v1, loose), '!cmp(' + v0 + '===' + v1 + ')');
-    t.ok(cmp(v0, '!==', v1, loose), 'cmp(' + v0 + '!==' + v1 + ')');
-    t.ok(!gt(v0, v1, loose), "!gt('" + v0 + "', '" + v1 + "')");
-    t.ok(gte(v0, v1, loose), "gte('" + v0 + "', '" + v1 + "')");
-    t.ok(!lt(v0, v1, loose), "!lt('" + v0 + "', '" + v1 + "')");
-    t.ok(lte(v0, v1, loose), "lte('" + v0 + "', '" + v1 + "')");
+    var stringForm = v[3];
+    t.ok(eq(v0, v1, loose, stringForm), "eq('" + v0 + "', '" + v1 + "')");
+    t.ok(!neq(v0, v1, loose, stringForm), "!neq('" + v0 + "', '" + v1 + "')");
+    t.ok(cmp(v0, '==', v1, loose, stringForm), 'cmp(' + v0 + '==' + v1 + ')');
+    t.ok(!cmp(v0, '!=', v1, loose, stringForm), '!cmp(' + v0 + '!=' + v1 + ')');
+    t.ok(!cmp(v0, '===', v1, loose, stringForm), '!cmp(' + v0 + '===' + v1 + ')');
+    t.ok(cmp(v0, '!==', v1, loose, stringForm), 'cmp(' + v0 + '!==' + v1 + ')');
+    t.ok(!gt(v0, v1, loose, stringForm), "!gt('" + v0 + "', '" + v1 + "')");
+    t.ok(gte(v0, v1, loose, stringForm), "gte('" + v0 + "', '" + v1 + "')");
+    t.ok(!lt(v0, v1, loose, stringForm), "!lt('" + v0 + "', '" + v1 + "')");
+    t.ok(lte(v0, v1, loose, stringForm), "lte('" + v0 + "', '" + v1 + "')");
   });
   t.end();
 });
-
 
 test('\nrange tests', function(t) {
   // [range, version]
@@ -225,12 +252,99 @@ test('\nrange tests', function(t) {
     ['^1.2 ^1', '1.4.2'],
     ['^1.2.3-alpha', '1.2.3-pre'],
     ['^1.2.0-alpha', '1.2.0-pre'],
-    ['^0.0.1-alpha', '0.0.1-beta']
+    ['^0.0.1-alpha', '0.0.1-beta'],
+    ['one point zero point zero - two point zero point zero', 'one dot two dot three', false, true],
+      ['^one dot two dot three+build', 'one dot two dot three', false, true],
+      ['^one dot two dot three+build', 'one dot three dot zero', false, true],
+      ['one dot two dot three-pre+asdf - two dot four dot three-pre+asdf', 'one dot two dot three', false, true],
+      ['one dot two dot three-pre+asdf - two dot four dot three-pre+asdf', 'one dot two dot three-pre.2', false, true],
+      ['one dot two dot three-pre+asdf - two dot four dot three-pre+asdf', 'two dot four dot three-alpha', false, true],
+      ['one dot two dot three+asdf - two dot four dot three+asdf', 'one dot two dot three', false, true],
+      ['one dot zero dot zero', 'one dot zero dot zero', false, true],
+      ['>=*', 'zero dot two dot four', false, true],
+      ['', 'one dot zero dot zero', false, true],
+      ['>=one dot zero dot zero', 'one dot zero dot zero', false, true],
+      ['>=one dot zero dot zero', 'one dot zero dot one', false, true],
+      ['>=one dot zero dot zero', 'one dot one dot zero', false, true],
+      ['>one dot zero dot zero', 'one dot zero dot one', false, true],
+      ['>one dot zero dot zero', 'one dot one dot zero', false, true],
+      ['<=two dot zero dot zero', 'two dot zero dot zero', false, true],
+      ['<=two dot zero dot zero', 'one dot nine thousand nine hundred ninety nine dot nine thousand nine hundred ninety nine', false, true],
+      ['<=two dot zero dot zero', 'zero dot two dot nine', false, true],
+      ['<two dot zero dot zero', 'one dot nine thousand nine hundred ninety nine dot nine thousand nine hundred ninety nine', false, true],
+      ['<two dot zero dot zero', 'zero dot two dot nine', false, true],
+      ['>= one dot zero dot zero', 'one dot zero dot zero', false, true],
+      ['>=  one dot zero dot zero', 'one dot zero dot one', false, true],
+      ['>=   one dot zero dot zero', 'one dot one dot zero', false, true],
+      ['> one dot zero dot zero', 'one dot zero dot one', false, true],
+      ['>  one dot zero dot zero', 'one dot one dot zero', false, true],
+      ['<=   two dot zero dot zero', 'two dot zero dot zero', false, true],
+      ['<= two dot zero dot zero', 'one dot nine thousand nine hundred ninety nine dot nine thousand nine hundred ninety nine', false, true],
+      ['<=  two dot zero dot zero', 'zero dot two dot nine', false, true],
+      ['<    two dot zero dot zero', 'one dot nine thousand nine hundred ninety nine dot nine thousand nine hundred ninety nine', false, true],
+      ['<\ttwo dot zero dot zero', 'zero dot two dot nine', false, true],
+      ['>=zero dot one dot ninety seven', 'zero dot one dot ninety seven', false, true],
+      ['zero dot one dot twenty || one dot two dot four', 'one dot two dot four', false, true],
+      ['>=zero dot two dot three || <zero dot zero dot one', 'zero dot zero dot zero', false, true],
+      ['>=zero dot two dot three || <zero dot zero dot one', 'zero dot two dot three', false, true],
+      ['>=zero dot two dot three || <zero dot zero dot one', 'zero dot two dot four', false, true],
+      ['||', 'one dot three dot four', false, true],
+      ['two dot x dot x', 'two dot one dot three', false, true],
+      ['one dot two dot x', 'one dot two dot three', false, true],
+      ['one dot two dot x || two dot x', 'two dot one dot three', false, true],
+      ['one dot two dot x || two dot x', 'one dot two dot three', false, true],
+      ['x', 'one dot two dot three', false, true],
+      ['two dot * dot *', 'two dot one dot three', false, true],
+      ['one dot two dot *', 'one dot two dot three', false, true],
+      ['one dot two dot * || two dot *', 'two dot one dot three', false, true],
+      ['one dot two dot * || two dot *', 'one dot two dot three', false, true],
+      ['*', 'one dot two dot three', false, true],
+      ['two', 'two dot one dot two', false, true],
+      ['two dot three', 'two dot three dot one', false, true],
+      ['~two dot four', 'two dot four dot zero', false, true], // >=two dot four dot zero <two dot five dot zero
+      ['~two dot four', 'two dot four dot five', false, true],
+      ['~>three dot two dot one', 'three dot two dot two', false, true], // >=three dot two dot one <three dot three dot zero,
+      ['~one', 'one dot two dot three', false, true], // >=one dot zero dot zero <two dot zero dot zero
+      ['~>one', 'one dot two dot three', false, true],
+      ['~> one', 'one dot two dot three', false, true],
+      ['~one dot zero', 'one dot zero dot two', false, true], // >=one dot zero dot zero <one dot one dot zero,
+      ['~ one dot zero', 'one dot zero dot two', false, true],
+      ['~ one dot zero dot three', 'one dot zero dot twelve', false, true],
+      ['>=one', 'one dot zero dot zero', false, true],
+      ['>= one', 'one dot zero dot zero', false, true],
+      ['<one dot two', 'one dot one dot one', false, true],
+      ['< one dot two', 'one dot one dot one', false, true],
+      ['~vzero dot five dot four-pre', 'zero dot five dot five', false, true],
+      ['~vzero dot five dot four-pre', 'zero dot five dot four', false, true],
+      ['=zero dot seven dot x', 'zero dot seven dot two', false, true],
+      ['<=zero dot seven dot x', 'zero dot seven dot two', false, true],
+      ['>=zero dot seven dot x', 'zero dot seven dot two', false, true],
+      ['<=zero dot seven dot x', 'zero dot six dot two', false, true],
+      ['~one dot two dot one >=one dot two dot three', 'one dot two dot three', false, true],
+      ['~one dot two dot one =one dot two dot three', 'one dot two dot three', false, true],
+      ['~one dot two dot one one dot two dot three', 'one dot two dot three', false, true],
+      ['~one dot two dot one >=one dot two dot three one dot two dot three', 'one dot two dot three', false, true],
+      ['~one dot two dot one one dot two dot three >=one dot two dot three', 'one dot two dot three', false, true],
+      ['~one dot two dot one one dot two dot three', 'one dot two dot three', false, true],
+      ['>=one dot two dot one one dot two dot three', 'one dot two dot three', false, true],
+      ['one dot two dot three >=one dot two dot one', 'one dot two dot three', false, true],
+      ['>=one dot two dot three >=one dot two dot one', 'one dot two dot three', false, true],
+      ['>=one dot two dot one >=one dot two dot three', 'one dot two dot three', false, true],
+      ['>=one dot two', 'one dot two dot eight', false, true],
+      ['^one dot two dot three', 'one dot eight dot one', false, true],
+      ['^zero dot one dot two', 'zero dot one dot two', false, true],
+      ['^zero dot one', 'zero dot one dot two', false, true],
+      ['^one dot two', 'one dot four dot two', false, true],
+      ['^one dot two ^one', 'one dot four dot two', false, true],
+      ['^one dot two dot three-alpha', 'one dot two dot three-pre', false, true],
+      ['^one dot two dot zero-alpha', 'one dot two dot zero-pre', false, true],
+      ['^zero dot zero dot one-alpha', 'zero dot zero dot one-beta', false, true]
   ].forEach(function(v) {
     var range = v[0];
     var ver = v[1];
     var loose = v[2];
-    t.ok(satisfies(ver, range, loose), range + ' satisfied by ' + ver);
+    var stringForm = v[3];
+    t.ok(satisfies(ver, range, loose, stringForm), range + ' satisfied by ' + ver);
   });
   t.end();
 });
@@ -305,7 +419,69 @@ test('\nnegative range tests', function(t) {
     // invalid ranges never satisfied!
     ['blerg', '1.2.3'],
     ['git+https://user:password0123@github.com/foo', '123.0.0', true],
-    ['^1.2.3', '2.0.0-pre']
+    ['^1.2.3', '2.0.0-pre'],
+
+    ['one point zero point zero - two point zero point zero', 'two point two point three', false, true],
+    ['one point two point three+asdf - two point four point three+asdf', 'one point two point three-pre point two', false, true],
+    ['one point two point three+asdf - two point four point three+asdf', 'two point four point three-alpha', false, true],
+    ['^one point two point three+build', 'two point zero point zero', false, true],
+    ['^one point two point three+build', 'one point two point zero', false, true],
+    ['^one point two point three', 'one point two point three-pre', false, true],
+    ['^one point two', 'one point two point zero-pre', false, true],
+    ['>one point two', 'one point three point zero-beta', false, true],
+    ['<=one point two point three', 'one point two point three-beta', false, true],
+    ['^one point two point three', 'one point two point three-beta', false, true],
+    ['=zero point seven point x', 'zero point seven point zero-asdf', false, true],
+    ['>=zero point seven point x', 'zero point seven point zero-asdf', false, true],
+    ['one point zero point zero', 'one point zero point one', false, true],
+    ['>=one point zero point zero', 'zero point zero point zero', false, true],
+    ['>=one point zero point zero', 'zero point zero point one', false, true],
+    ['>=one point zero point zero', 'zero point one point zero', false, true],
+    ['>one point zero point zero', 'zero point zero point one', false, true],
+    ['>one point zero point zero', 'zero point one point zero', false, true],
+    ['<=two point zero point zero', 'three point zero point zero', false, true],
+    ['<=two point zero point zero', 'two point nine thousand nine hundred ninety nine point nine thousand nine hundred ninety nine', false, true],
+    ['<=two point zero point zero', 'two point two point nine', false, true],
+    ['<two point zero point zero', 'two point nine thousand nine hundred ninety nine point nine thousand nine hundred ninety nine', false, true],
+    ['<two point zero point zero', 'two point two point nine', false, true],
+    ['>=zero point one point ninety seven', 'zero point one point ninety three', false, true],
+    ['zero point one point twenty || one point two point four', 'one point two point three', false, true],
+    ['>=zero point two point three || <zero point zero point one', 'zero point zero point three', false, true],
+    ['>=zero point two point three || <zero point zero point one', 'zero point two point two', false, true],
+    ['two point x point x', 'one point one point three', false, true],
+    ['two point x point x', 'three point one point three', false, true],
+    ['one point two point x', 'one point three point three', false, true],
+    ['one point two point x || two point x', 'three point one point three', false, true],
+    ['one point two point x || two point x', 'one point one point three', false, true],
+    ['two point * point *', 'one point one point three', false, true],
+    ['two point * point *', 'three point one point three', false, true],
+    ['one point two point *', 'one point three point three', false, true],
+    ['one point two point * || two point *', 'three point one point three', false, true],
+    ['one point two point * || two point *', 'one point one point three', false, true],
+    ['two', 'one point one point two', false, true],
+    ['two point three', 'two point four point one', false, true],
+    ['~two point four', 'two point five point zero', false, true], // >=two point four point zero <two point five point zero
+    ['~two point four', 'two point three point nine', false, true],
+    ['~>three point two point one', 'three point three point two', false, true], // >=three point two point one <three point three point zero
+    ['~>three point two point one', 'three point two point zero', false, true], // >=three point two point one <three point three point zero
+    ['~one', 'zero point two point three', false, true], // >=one point zero point zero <two point zero point zero
+    ['~>one', 'two point two point three', false, true],
+    ['~one point zero', 'one point one point zero', false, true], // >=one point zero point zero <one point one point zero
+    ['<one', 'one point zero point zero', false, true],
+    ['>=one point two', 'one point one point one', false, true],
+    ['~vzero point five point four-beta', 'zero point five point four-alpha', false, true],
+    ['=zero point seven point x', 'zero point eight point two', false, true],
+    ['>=zero point seven point x', 'zero point six point two', false, true],
+    ['<zero point seven point x', 'zero point seven point two', false, true],
+    ['<one point two point three', 'one point two point three-beta', false, true],
+    ['=one point two point three', 'one point two point three-beta', false, true],
+    ['>one point two', 'one point two point eight', false, true],
+    ['^one point two point three', 'two point zero point zero-alpha', false, true],
+    ['^one point two point three', 'one point two point two', false, true],
+    ['^one point two', 'one point one point nine', false, true],
+    // invalid ranges never satisfied!
+    ['blerg', 'one point two point three', false, true],
+    ['^one point two point three', 'two point zero point zero-pre', false, true]
   ].forEach(function(v) {
     var range = v[0];
     var ver = v[1];
@@ -531,12 +707,82 @@ test('\nvalid range test', function(t) {
     ['>01.02.03', null],
     ['~1.2.3beta', '>=1.2.3-beta <1.3.0', true],
     ['~1.2.3beta', null],
-    ['^ 1.2 ^ 1', '>=1.2.0 <2.0.0 >=1.0.0 <2.0.0']
+    ['^ 1.2 ^ 1', '>=1.2.0 <2.0.0 >=1.0.0 <2.0.0'],
+
+    ['one dot zero dot zero - two dot zero dot zero', '>=1.0.0 <=2.0.0', false, true],
+    ['one dot zero dot zero', '1.0.0', false, true],
+    ['>=*', '*', false, true],
+    ['', '*', false, true],
+    ['*', '*', false, true],
+    ['*', '*', false, true],
+    ['>=one dot zero dot zero', '>=1.0.0', false, true],
+    ['>one dot zero dot zero', '>1.0.0', false, true],
+    ['<=two dot zero dot zero', '<=2.0.0', false, true],
+    ['one', '>=1.0.0 <2.0.0', false, true],
+    ['<=two dot zero dot zero', '<=2.0.0', false, true],
+    ['<=two dot zero dot zero', '<=2.0.0', false, true],
+    ['<two dot zero dot zero', '<2.0.0', false, true],
+    ['<two dot zero dot zero', '<2.0.0', false, true],
+    ['>= one dot zero dot zero', '>=1.0.0', false, true],
+    ['>=  one dot zero dot zero', '>=1.0.0', false, true],
+    ['>=   one dot zero dot zero', '>=1.0.0', false, true],
+    ['> one dot zero dot zero', '>1.0.0', false, true],
+    ['>  one dot zero dot zero', '>1.0.0', false, true],
+    ['<=   two dot zero dot zero', '<=2.0.0', false, true],
+    ['<= two dot zero dot zero', '<=2.0.0', false, true],
+    ['<=  two dot zero dot zero', '<=2.0.0', false, true],
+    ['<    two dot zero dot zero', '<2.0.0', false, true],
+    ['<	two dot zero dot zero', '<2.0.0', false, true],
+    ['>=zero dot one dot ninety seven', '>=0.1.97', false, true],
+    ['>=zero dot one dot ninety seven', '>=0.1.97', false, true],
+    ['zero dot one dot twenty || one dot two dot four', '0.1.20||1.2.4', false, true],
+    ['>=zero dot two dot three || <zero dot zero dot one', '>=0.2.3||<0.0.1', false, true],
+    ['>=zero dot two dot three || <zero dot zero dot one', '>=0.2.3||<0.0.1', false, true],
+    ['>=zero dot two dot three || <zero dot zero dot one', '>=0.2.3||<0.0.1', false, true],
+    ['||', '||', false, true],
+    ['two dot x dot x', '>=2.0.0 <3.0.0', false, true],
+    ['one dot two dot x', '>=1.2.0 <1.3.0', false, true],
+    ['one dot two dot x || two dot x', '>=1.2.0 <1.3.0||>=2.0.0 <3.0.0', false, true],
+    ['one dot two dot x || two dot x', '>=1.2.0 <1.3.0||>=2.0.0 <3.0.0', false, true],
+    ['x', '*', false, true],
+    ['two dot * dot *', '>=2.0.0 <3.0.0', false, true],
+    ['one dot two dot *', '>=1.2.0 <1.3.0', false, true],
+    ['one dot two dot * || two dot *', '>=1.2.0 <1.3.0||>=2.0.0 <3.0.0', false, true],
+    ['*', '*', false, true],
+    ['two', '>=2.0.0 <3.0.0', false, true],
+    ['two dot three', '>=2.3.0 <2.4.0', false, true],
+    ['~two dot four', '>=2.4.0 <2.5.0', false, true],
+    ['~>three dot two dot one', '>=3.2.1 <3.3.0', false, true],
+    ['~one', '>=1.0.0 <2.0.0', false, true],
+    ['~>one', '>=1.0.0 <2.0.0', false, true],
+    ['~> one', '>=1.0.0 <2.0.0', false, true],
+    ['~one dot zero', '>=1.0.0 <1.1.0', false, true],
+    ['~ one dot zero', '>=1.0.0 <1.1.0', false, true],
+    ['^zero', '>=0.0.0 <1.0.0', false, true],
+    ['^ one', '>=1.0.0 <2.0.0', false, true],
+    ['^zero dot one', '>=0.1.0 <0.2.0', false, true],
+    ['^one dot zero', '>=1.0.0 <2.0.0', false, true],
+    ['^one dot two', '>=1.2.0 <2.0.0', false, true],
+    ['^zero dot zero dot one', '>=0.0.1 <0.0.2', false, true],
+    ['^zero dot zero dot one-beta', '>=0.0.1-beta <0.0.2', false, true],
+    ['^zero dot one dot two', '>=0.1.2 <0.2.0', false, true],
+    ['^one dot two dot three', '>=1.2.3 <2.0.0', false, true],
+    ['^one dot two dot three-beta.4', '>=1.2.3-beta.4 <2.0.0', false, true],
+    ['<one', '<1.0.0', false, true],
+    ['< one', '<1.0.0', false, true],
+    ['>=one', '>=1.0.0', false, true],
+    ['>= one', '>=1.0.0', false, true],
+    ['<one dot two', '<1.2.0', false, true],
+    ['< one dot two', '<1.2.0', false, true],
+    ['one', '>=1.0.0 <2.0.0', false, true],
+    ['~one dot two dot threebeta', null, false, true],
+    ['^ one dot two ^ one', '>=1.2.0 <2.0.0 >=1.0.0 <2.0.0', false, true]
   ].forEach(function(v) {
     var pre = v[0];
     var wanted = v[1];
     var loose = v[2];
-    var found = validRange(pre, loose);
+    var stringForm = v[3];
+    var found = validRange(pre, loose, stringForm);
 
     t.equal(found, wanted, 'validRange(' + pre + ') === ' + wanted);
   });


### PR DESCRIPTION
Pure numbers are error prone and hard to read. With string representations, one can be much more explicit about their versioning.

With a very terse format like `1.2.3` the probability of typos occurring, causing skipped numbers, increases. I propose a system-wide switch to string representations of numbers where versions would be written like `one dot two dot three` or `fourteen point five point three hundred fourty four`. I believe this format is much more explicit and error resilient than the purely numeric representation.

(April Fool's y'all! 😆 )