### PR TITLE
Optional prerelease version lock

### DIFF
--- a/semver.js
+++ b/semver.js
@@ -1028,7 +1028,7 @@ function hyphenReplace($0,
 
 
 // if ANY of the sets match ALL of its comparators, then pass
-Range.prototype.test = function(version) {
+Range.prototype.test = function(version, prereleaseLock) {
   if (!version)
     return false;
 
@@ -1036,19 +1036,23 @@ Range.prototype.test = function(version) {
     version = new SemVer(version, this.loose);
 
   for (var i = 0; i < this.set.length; i++) {
-    if (testSet(this.set[i], version))
+    if (testSet(this.set[i], version, prereleaseLock))
       return true;
   }
   return false;
 };
 
-function testSet(set, version) {
+function testSet(set, version, prereleaseLock) {
   for (var i = 0; i < set.length; i++) {
     if (!set[i].test(version))
       return false;
   }
 
-  if (version.prerelease.length) {
+  if (prereleaseLock === undefined) {
+    prereleaseLock = true;
+  }
+
+  if (version.prerelease.length && prereleaseLock) {
     // Find the set of versions that are allowed to have prereleases
     // For example, ^1.2.3-pr.1 desugars to >=1.2.3-pr.1 <2.0.0
     // That should allow `1.2.3-pr.2` to pass.
@@ -1076,13 +1080,13 @@ function testSet(set, version) {
 }
 
 exports.satisfies = satisfies;
-function satisfies(version, range, loose) {
+function satisfies(version, range, loose, prereleaseLock) {
   try {
     range = new Range(range, loose);
   } catch (er) {
     return false;
   }
-  return range.test(version);
+  return range.test(version, prereleaseLock);
 }
 
 exports.maxSatisfying = maxSatisfying;

--- a/test/index.js
+++ b/test/index.js
@@ -316,6 +316,39 @@ test('\nnegative range tests', function(t) {
   t.end();
 });
 
+test('\nunlocked prerelease range tests', function(t) {
+  // [range, version]
+  // version should be included by range
+  [['*', '1.0.0-rc1'],
+    ['^1.0.0', '2.0.0-rc1'],
+    ['^1.0.0-0', '1.0.1-rc1'],
+    ['^1.0.0-rc2', '1.0.1-rc1'],
+    ['^1.0.0', '1.0.1-rc1'],
+    ['^1.0.0', '1.1.0-rc1']
+  ].forEach(function(v) {
+    var range = v[0];
+    var ver = v[1];
+    var loose = v[2];
+    t.ok(satisfies(ver, range, loose, false), range + ' satisfied by ' + ver);
+  });
+  t.end();
+});
+
+test('\nnegative unlocked prerelease range tests', function(t) {
+  // [range, version]
+  // version should not be included by range
+  [['^1.0.0', '1.0.0-rc1'],
+    ['^1.2.3-rc2', '2.0.0'],
+  ].forEach(function(v) {
+    var range = v[0];
+    var ver = v[1];
+    var loose = v[2];
+    var found = satisfies(ver, range, loose, false);
+    t.ok(!found, ver + ' not satisfied by ' + range);
+  });
+  t.end();
+});
+
 test('\nincrement versions test', function(t) {
 //  [version, inc, result, identifier]
 //  inc(version, inc) -> result


### PR DESCRIPTION
Prerelease versions are currently only satisfied by ranges containing a prerelease tag with the same `[major, minor, patch]` tuple as [documented](https://github.com/protyposis/node-semver/blob/aaba7103e1837c4ecbfe8aff956d08adf67240a1/README.md#prerelease-tags), which makes sense for the default use-cases of this library.

I currently have a use-case where I want to to specify version ranges of test cases to be run for certain versions of a tested software component. E.g. to run a test on all versions that ever exist, including prerelease versions (e.g. release candidates), I want to specify the range '*'. To run a test on all versions starting with prereleases of '2.0.0', I specify the range '>=2.0.0-0'. '>=2.0.0-0' should thus match '2.0.0-rc1', '2.0.0', '2.1.0-rc1', '2.2.0', etc., which is currently prevented by the `[major, minor, patch]` prerelease version lock.

To be able to use this library in such cases, I added an additional parameter **`prereleaseLock`** to the `satisfies` method (`satisfies(version, range, loose, prereleaseLock)`), which is `true` by default to get the default version locking behavior, and disables the version lock behavior when set to `false`. This is basically what has been described by @isaacs in #130 ([here](https://github.com/npm/node-semver/issues/130#issuecomment-121095949).