### PR TITLE
range.bnf: Fix invalid bracket expression

### DIFF
--- a/range.bnf
+++ b/range.bnf
@@ -6,7 +6,7 @@ simple     ::= primitive | partial | tilde | caret
 primitive  ::= ( '<' | '>' | '>=' | '<=' | '=' ) partial
 partial    ::= xr ( '.' xr ( '.' xr qualifier ? )? )?
 xr         ::= 'x' | 'X' | '*' | nr
-nr         ::= '0' | ['1'-'9'] ( ['0'-'9'] ) *
+nr         ::= '0' | [1-9] ( [0-9] ) *
 tilde      ::= '~' partial
 caret      ::= '^' partial
 qualifier  ::= ( '-' pre )? ( '+' build )?


### PR DESCRIPTION
`nr` uses `['1'-'9']` and `['0'-'9']`, which are equivalent to `['19]`
and `['09]` respectively.  This is modified to `[1-9]` and `[0-9]` to
match the syntax used in the `part` rule, fixing the productions.