### PR TITLE
add minVersion function

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ strings that they parse.
 ### Ranges
 
 * `validRange(range)`: Return the valid range or null if it's not valid
+* `minVersion(range)`: Return the lowest version that satisfies the range.
 * `satisfies(version, range)`: Return true if the version satisfies the
   range.
 * `maxSatisfying(versions, range)`: Return the highest version in the list

--- a/semver.js
+++ b/semver.js
@@ -1200,6 +1200,19 @@ function validRange(range, loose) {
   }
 }
 
+exports.minVersion = minVersion;
+function minVersion(range, loose) {
+  try {
+    var rangeObj = new Range(range, loose);
+  } catch (er) {
+    return null;
+  }
+  if (!rangeObj.range) {
+    return '0.0.0';
+  }
+  return rangeObj.set[0][0].semver.version;
+}
+
 // Determine if version is less than all the versions possible in the range
 exports.ltr = ltr;
 function ltr(version, range, loose) {

--- a/test/index.js
+++ b/test/index.js
@@ -695,6 +695,22 @@ test('\nstrict vs loose ranges', function(t) {
   t.end();
 });
 
+test('\nmin version', function(t) {
+  [['1.2', '1.2.0'],
+    ['>=2.1.0 <2.2.0', '2.1.0'],
+    ['', '0.0.0'],
+    ['~3.3', '3.3.0', true],
+    ['invalid range', null]
+  ].forEach(function(v) {
+    var range = v[0];
+    var expect = v[1];
+    var loose = v[2];
+    var actual = semver.minVersion(range, loose);
+    t.equal(actual, expect);
+  });
+  t.end();
+});
+
 test('\nmax satisfying', function(t) {
   [[['1.2.3', '1.2.4'], '1.2', '1.2.4'],
     [['1.2.4', '1.2.3'], '1.2', '1.2.4'],


### PR DESCRIPTION
I'm trying to decide which range is "newer" when automatically updating package.json [here](https://github.com/kellyselden/ember-cli-update/pull/108) and [here](https://github.com/bantic/three-way-merger). The scenario is

* my dep is "a": "^2.0.2"
* upstream was updated "a": "^1.4.0" => "a": "^2.0.0"

I want to be smart and say, even though the dep was updated, mine is more recent, so ignore the change. My pseudocode is `if myDepRange < newDepRange then update`.

Getting the lowest possible version in a range seems like a good way to compare two ranges for newest. I currently am doing:

```js
function minVersion(range) {
  return new Range(range).set[0][0].semver.version;
}
```

But I feel like I'm reaching into too much private API. I would like add this function upstream to this library.