### PR TITLE
Fixed test running error by upgrading tap to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tap test/*.js --cov -J"
   },
   "devDependencies": {
-    "tap": "^10.7.0"
+    "tap": "^10.7.2"
   },
   "license": "ISC",
   "repository": "https://github.com/npm/node-semver",


### PR DESCRIPTION
Tried to run the tests, got the following error:

"Error: Cannot find module 'C:\<my_folder>\.node-spawn-wrap-8132-0aeecd456c09\node.EXE'
    at Function.Module._resolveFilename (module.js:527:15)
    at Function.Module._load (module.js:453:25)
    at Function.Module.runMain (module.js:665:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3"

Based on [this](https://github.com/tapjs/spawn-wrap/issues/56) thread, upgrading tap helps. I tried it, and it solved the issue.