### PR TITLE
Fix #225: intersects with ANY throws a TypeError

### DIFF
--- a/semver.js
+++ b/semver.js
@@ -721,6 +721,10 @@ Comparator.prototype.intersects = function(comp, loose) {
     throw new TypeError('a Comparator is required');
   }
 
+  if (this.semver === ANY || comp.semver === ANY) {
+    return true;
+  }
+
   var rangeTmp;
 
   if (this.operator === '') {

--- a/test/index.js
+++ b/test/index.js
@@ -803,7 +803,14 @@ test('\nranges intersect', function(t) {
     ['<1.0.0 >2.0.0', '>1.4.0 <1.6.0 || 2.0.0', false],
     ['>1.0.0 <=2.0.0', '2.0.0', true],
     ['<1.0.0 >=2.0.0', '2.1.0', false],
-    ['<1.0.0 >=2.0.0', '>1.4.0 <1.6.0 || 2.0.0', false]
+    ['<1.0.0 >=2.0.0', '>1.4.0 <1.6.0 || 2.0.0', false],
+    // check caret, tilde ranges per issues 225 and 236
+    ['*', '^1.2.3', true],
+    ['x', '^1.2.3', true],
+    ['', '^1.2.3', true],
+    ['*', '~1.2.3', true],
+    ['x', '~1.2.3', true],
+    ['', '~1.2.3', true]
   ].forEach(function(v) {
     var range1 = new Range(v[0]);
     var range2 = new Range(v[1]);


### PR DESCRIPTION
Fix #225: `intersects('*', '^1.2.3')` throws a TypeError
and #236: A range of "*" cannot call intersects on ranges with "^" or "~" 

On entry to Comparator.prototype.intersects, if either this.semver or comp.semver are ANY, return true.
