### PR TITLE
Fix grammar for ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ logical-or ::= ( ' ' ) * '||' ( ' ' ) *
 range      ::= hyphen | simple ( ' ' simple ) * | ''
 hyphen     ::= partial ' - ' partial
 simple     ::= primitive | partial | tilde | caret
-primitive  ::= ( '<' | '>' | '>=' | '<=' | '=' | ) partial
+primitive  ::= ( '<' | '>' | '>=' | '<=' | '=' ) partial
 partial    ::= xr ( '.' xr ( '.' xr qualifier ? )? )?
 xr         ::= 'x' | 'X' | '*' | nr
 nr         ::= '0' | ['1'-'9'] ( ['0'-'9'] ) *


### PR DESCRIPTION
This *might* be wrong, so please let me know!

I took the `| ` in this line to be the "with no operation" case, but the rule right above has

    simple     ::= primitive | partial | tilde | caret

so, the "no operator" case is already covered. This makes me think the `|  ` was a typo, so it should be removed.