### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ semver(1) -- The semantic versioner for npm
 ## Install
 
 ```bash
-npm install --save semver
+npm install semver
 ````
 
 ## Usage


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358