### PR TITLE
export new RELEASE_TYPES constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,3 +441,39 @@ ex.
 * `s.clean('  =v2.1.5')`: `2.1.5`
 * `s.clean('      2.1.5   ')`: `'2.1.5'`
 * `s.clean('~1.0.0')`: `null`
+
+
+## Constants
+
+As a convenience, helper constants are exported to provide information about what `node-semver` supports:
+
+### `RELEASE_TYPES`
+
+- major
+- premajor
+- minor
+- preminor
+- patch
+- prepatch
+- prerelease
+
+```
+const semver = require('semver');
+
+if (semver.RELEASE_TYPES.includes(arbitraryUserInput)) {
+  console.log('This is a valid release type!');
+} else {
+  console.warn('This is NOT a valid release type!');
+}
+```
+
+### `SEMVER_SPEC_VERSION`
+
+2.0.0
+
+```
+const semver = require('semver');
+
+console.log('We are currently using the semver specification version:', semver.SEMVER_SPEC_VERSION);
+```
+

--- a/semver.js
+++ b/semver.js
@@ -18,6 +18,15 @@ if (typeof process === 'object' &&
 // Note: this is the semver.org version of the spec that it implements
 // Not necessarily the package version of this code.
 exports.SEMVER_SPEC_VERSION = '2.0.0'
+exports.RELEASE_TYPES = [
+    "major",
+    "premajor",
+    "minor",
+    "preminor",
+    "patch",
+    "prepatch",
+    "prerelease"
+];
 
 var MAX_LENGTH = 256
 var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER ||


### PR DESCRIPTION
This will help library consumers better integrate semver into their apps.

Possible usecases of consuming this constant:

- Automatically show a dropdown of available release types that conform to the semver spec
- Validate user inputs where a release type is expected