### PR TITLE
Add preload.js into NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "functions",
     "internal",
     "ranges",
-    "index.js"
+    "index.js",
+    "preload.js"
   ],
   "tap": {
     "check-coverage": true,


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
preload.js is missing in NPM package as it is not mentioned in files section of package.json

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
