### PR TITLE
Fixed variable names and comments

### DIFF
--- a/test/fixtures/version-gt-range.js
+++ b/test/fixtures/version-gt-range.js
@@ -1,4 +1,4 @@
-// [range, version, loose]
+// [range, version, options]
 // Version should be greater than range
 module.exports = [
   ['~1.2.2', '1.3.0'],

--- a/test/fixtures/version-lt-range.js
+++ b/test/fixtures/version-lt-range.js
@@ -1,4 +1,4 @@
-// [range, version, loose]
+// [range, version, options]
 // Version should be less than range
 module.exports = [
   ['~1.2.2', '1.2.1'],

--- a/test/fixtures/version-not-gt-range.js
+++ b/test/fixtures/version-not-gt-range.js
@@ -1,4 +1,4 @@
-// [range, version, loose]
+// [range, version, options]
 // Version should NOT be greater than range
 module.exports = [
   ['~0.6.1-1', '0.6.1-1'],

--- a/test/fixtures/version-not-lt-range.js
+++ b/test/fixtures/version-not-lt-range.js
@@ -1,4 +1,4 @@
-// [range, version, loose]
+// [range, version, options]
 // Version should NOT be less than range
 module.exports = [
   ['~ 1.0', '1.1.0'],

--- a/test/ranges/gtr.js
+++ b/test/ranges/gtr.js
@@ -4,27 +4,27 @@ const versionGtr = require('../fixtures/version-gt-range')
 const versionNotGtr = require('../fixtures/version-not-gt-range')
 
 test('gtr tests', (t) => {
-  // [range, version, loose]
+  // [range, version, options]
   // Version should be greater than range
   versionGtr.forEach((tuple) => {
     const range = tuple[0]
     const version = tuple[1]
-    const loose = tuple[2] || false
-    const msg = `gtr(${version}, ${range}, ${loose})`
-    t.ok(gtr(version, range, loose), msg)
+    const options = tuple[2] || false
+    const msg = `gtr(${version}, ${range}, ${options})`
+    t.ok(gtr(version, range, options), msg)
   })
   t.end()
 })
 
 test('negative gtr tests', (t) => {
-  // [range, version, loose]
+  // [range, version, options]
   // Version should NOT be greater than range
   versionNotGtr.forEach((tuple) => {
     const range = tuple[0]
     const version = tuple[1]
-    const loose = tuple[2] || false
-    const msg = `!gtr(${version}, ${range}, ${loose})`
-    t.notOk(gtr(version, range, loose), msg)
+    const options = tuple[2] || false
+    const msg = `!gtr(${version}, ${range}, ${options})`
+    t.notOk(gtr(version, range, options), msg)
   })
   t.end()
 })

--- a/test/ranges/ltr.js
+++ b/test/ranges/ltr.js
@@ -4,21 +4,21 @@ const versionLtr = require('../fixtures/version-lt-range')
 const versionNotLtr = require('../fixtures/version-not-lt-range')
 
 test('ltr tests', (t) => {
-  // [range, version, loose]
+  // [range, version, options]
   // Version should be less than range
-  versionLtr.forEach(([range, version, loose = false]) => {
-    const msg = `ltr(${version}, ${range}, ${loose})`
-    t.ok(ltr(version, range, loose), msg)
+  versionLtr.forEach(([range, version, options = false]) => {
+    const msg = `ltr(${version}, ${range}, ${options})`
+    t.ok(ltr(version, range, options), msg)
   })
   t.end()
 })
 
 test('negative ltr tests', (t) => {
-  // [range, version, loose]
+  // [range, version, options]
   // Version should NOT be less than range
-  versionNotLtr.forEach(([range, version, loose = false]) => {
-    const msg = `!ltr(${version}, ${range}, ${loose})`
-    t.notOk(ltr(version, range, loose), msg)
+  versionNotLtr.forEach(([range, version, options = false]) => {
+    const msg = `!ltr(${version}, ${range}, ${options})`
+    t.notOk(ltr(version, range, options), msg)
   })
   t.end()
 })

--- a/test/ranges/outside.js
+++ b/test/ranges/outside.js
@@ -6,41 +6,41 @@ const versionLtr = require('../fixtures/version-lt-range')
 const versionNotLtr = require('../fixtures/version-not-lt-range')
 
 test('gtr tests', (t) => {
-  // [range, version, loose]
+  // [range, version, options]
   // Version should be greater than range
-  versionGtr.forEach(([range, version, loose = false]) => {
-    const msg = `outside(${version}, ${range}, > ${loose})`
-    t.ok(outside(version, range, '>', loose), msg)
+  versionGtr.forEach(([range, version, options = false]) => {
+    const msg = `outside(${version}, ${range}, > ${options})`
+    t.ok(outside(version, range, '>', options), msg)
   })
   t.end()
 })
 
 test('ltr tests', (t) => {
-  // [range, version, loose]
+  // [range, version, options]
   // Version should be less than range
-  versionLtr.forEach(([range, version, loose = false]) => {
-    const msg = `outside(${version}, ${range}, <, ${loose})`
-    t.ok(outside(version, range, '<', loose), msg)
+  versionLtr.forEach(([range, version, options = false]) => {
+    const msg = `outside(${version}, ${range}, <, ${options})`
+    t.ok(outside(version, range, '<', options), msg)
   })
   t.end()
 })
 
 test('negative gtr tests', (t) => {
-  // [range, version, loose]
+  // [range, version, options]
   // Version should NOT be greater than range
-  versionNotGtr.forEach(([range, version, loose = false]) => {
-    const msg = `!outside(${version}, ${range}, > ${loose})`
-    t.notOk(outside(version, range, '>', loose), msg)
+  versionNotGtr.forEach(([range, version, options = false]) => {
+    const msg = `!outside(${version}, ${range}, > ${options})`
+    t.notOk(outside(version, range, '>', options), msg)
   })
   t.end()
 })
 
 test('negative ltr tests', (t) => {
-  // [range, version, loose]
+  // [range, version, options]
   // Version should NOT be less than range
-  versionNotLtr.forEach(([range, version, loose = false]) => {
-    const msg = `!outside(${version}, ${range}, < ${loose})`
-    t.notOk(outside(version, range, '<', loose), msg)
+  versionNotLtr.forEach(([range, version, options = false]) => {
+    const msg = `!outside(${version}, ${range}, < ${options})`
+    t.notOk(outside(version, range, '<', options), msg)
   })
   t.end()
 })


### PR DESCRIPTION
# Cleanup var names and comments

This is a cleanup PR only. No functional changes.

While looking at tests, I encountered inappropriate comments and variable names. This cleanup makes it more obvious that { includePrerelease: true | false } can be added to tests.