### PR TITLE
MinVersion failing for '^2.16.2 ^2.16' alike range

### DIFF
--- a/ranges/min-version.js
+++ b/ranges/min-version.js
@@ -33,7 +33,7 @@ const minVersion = (range, loose) => {
           /* fallthrough */
         case '':
         case '>=':
-          if (!minver || gt(minver, compver)) {
+          if (!minver || gt(compver, minver)) {
             minver = compver
           }
           break


### PR DESCRIPTION
It seems like the logic was incorrect, after switching the order of comparatement, the `minVersion` started to return proper results.

## References

Fixes #340
Closes #340