### PR TITLE
Remove useless regular-expression character escape

### DIFF
--- a/internal/re.js
+++ b/internal/re.js
@@ -178,5 +178,5 @@ createToken('HYPHENRANGELOOSE', `^\\s*(${src[t.XRANGEPLAINLOOSE]})` +
 // Star ranges basically just allow anything at all.
 createToken('STAR', '(<|>)?=?\\s*\\*')
 // >=0.0.0 is like a star
-createToken('GTE0', '^\\s*>=\\s*0\.0\.0\\s*$')
-createToken('GTE0PRE', '^\\s*>=\\s*0\.0\.0-0\\s*$')
+createToken('GTE0', '^\\s*>=\\s*0.0.0\\s*$')
+createToken('GTE0PRE', '^\\s*>=\\s*0.0.0-0\\s*$')


### PR DESCRIPTION
This PR fixes the problem found by #358 (though it's hardly a problem).