### PR TITLE
fix(subset): check any as superset

### DIFF
--- a/ranges/subset.js
+++ b/ranges/subset.js
@@ -7,6 +7,8 @@ const compare = require('../functions/compare.js')
 // - Every simple range `r1, r2, ...` is a subset of some `R1, R2, ...`
 //
 // Simple range `c1 c2 ...` is a subset of simple range `C1 C2 ...` iff:
+// - If C is only the ANY comparator
+//   - return true
 // - If c is only the ANY comparator
 //   - If C is only the ANY comparator, return true
 //   - Else return false
@@ -56,6 +58,9 @@ const subset = (sub, dom, options) => {
 
 const simpleSubset = (sub, dom, options) => {
   if (sub === dom)
+    return true
+
+  if (dom.length === 1 && dom[0].semver === ANY)
     return true
 
   if (sub.length === 1 && sub[0].semver === ANY)

--- a/test/ranges/subset.js
+++ b/test/ranges/subset.js
@@ -15,6 +15,12 @@ const cases = [
   ['>2 <1', '3', true],
   ['1 || 2 || 3', '>=1.0.0', true],
 
+  // everything is a subset of *
+  ['1.2.3', '*', true],
+  ['^1.2.3', '*', true],
+  ['^1.2.3-pre.0', '*', true],
+  ['1 || 2 || 3', '*', true],
+
   ['*', '*', true],
   ['', '*', true],
   ['*', '', true],


### PR DESCRIPTION
## Summary

Adds short-circuit check if superset is `*`. This is currently not handled. A non-range semver has been able to get passed this not existing, but ranges came back falsey. This request addresses that shortcoming.

## References

Fixes #374.
