### PR TITLE
fix: inc prerelease with numeric preid

### DIFF
--- a/classes/semver.js
+++ b/classes/semver.js
@@ -265,7 +265,7 @@ class SemVer {
         if (identifier) {
           // 1.2.0-beta.1 bumps to 1.2.0-beta.2,
           // 1.2.0-beta.fooblz or 1.2.0-beta bumps to 1.2.0-beta.0
-          if (this.prerelease[0] === identifier) {
+          if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
             if (isNaN(this.prerelease[1])) {
               this.prerelease = [identifier, 0]
             }

--- a/test/fixtures/increments.js
+++ b/test/fixtures/increments.js
@@ -82,4 +82,9 @@ module.exports = [
   ['1.2.0-1', 'minor', '1.2.0', false, 'dev'],
   ['1.0.0-1', 'major', '1.0.0', 'dev'],
   ['1.2.3-dev.bar', 'prerelease', '1.2.3-dev.0', false, 'dev'],
+
+  ['1.2.3-0', 'prerelease', '1.2.3-1.0', false, '1'],
+  ['1.2.3-1.0', 'prerelease', '1.2.3-1.1', false, '1'],
+  ['1.2.3-1.1', 'prerelease', '1.2.3-1.2', false, '1'],
+  ['1.2.3-1.1', 'prerelease', '1.2.3-2.0', false, '2'],
 ]


### PR DESCRIPTION
The [semver spec](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions) says prerelease can be numeric:

```
<pre-release identifier> ::= <alphanumeric identifier>
                           | <numeric identifier>
```

This PR fixes `inc` `prerelease` with numeric `preid`.

E.g. `inc('1.0.0-1.0', 'prerelease', '1')` should return `1.0.0-1.1`, but today it returns `1.0.0-1.0`.

The bug is that currently it compares preid with `this.prerelease[0] === identifier`, and a string `'1'` is not equal to number `1`, thus it's returning incorrect result. Change this comparison to use `compareIdentifiers` just like everywhere else fixes the problem.

- Fixes https://github.com/npm/cli/issues/3181