### PR TITLE
Satisfies should not be true for different identifiers

### DIFF
--- a/test/functions/satisfies.js
+++ b/test/functions/satisfies.js
@@ -26,3 +26,10 @@ test('invalid ranges never satisfied (but do not throw)', t => {
   cases.forEach(([range, ver]) =>
     t.notOk(satisfies(ver, range), `${range} not satisfied because invalid`))
 })
+
+test('prereleases', t => {
+  t.plan(2)
+  t.notOk(satisfies('3.1.10-pre', '^3.1.10-a'), 'not satisfied because names are different')
+  t.ok(satisfies('3.1.10-pre.74', '^3.1.10-pre.73'), 'satisfied because name is the same and version is greater')
+  t.notOk(satisfies('3.1.10-pre.72', '^3.1.10-pre.73'), 'not satisfied because name is the same but version is less')
+})


### PR DESCRIPTION
This is currently just a failing test for `satisfies('3.1.10-pre', '^3.1.10-a') === false`, and a few other assertions that I didn't see tested anywhere else and wouldn't want to break in a fix for this.


## References
Related to https://github.com/npm/node-semver/issues/331
