### PR TITLE
fix: ensure SemVer instance passed to inc are not modified

### DIFF
--- a/functions/inc.js
+++ b/functions/inc.js
@@ -7,7 +7,10 @@ const inc = (version, release, options, identifier) => {
   }
 
   try {
-    return new SemVer(version, options).inc(release, identifier).version
+    return new SemVer(
+      version instanceof SemVer ? version.version : version,
+      options
+    ).inc(release, identifier).version
   } catch (er) {
     return null
   }

--- a/test/functions/inc.js
+++ b/test/functions/inc.js
@@ -10,10 +10,20 @@ test('increment versions test', (t) => {
     t.equal(found, wanted, `${cmd} === ${wanted}`)
 
     const parsed = parse(pre, options)
+    const parsedAsInput = parse(pre, options)
     if (wanted) {
       parsed.inc(what, id)
       t.equal(parsed.version, wanted, `${cmd} object version updated`)
       t.equal(parsed.raw, wanted, `${cmd} object raw field updated`)
+
+      const preIncObject = JSON.stringify(parsedAsInput)
+      inc(parsedAsInput, what, options, id)
+      const postIncObject = JSON.stringify(parsedAsInput)
+      t.equal(
+        postIncObject,
+        preIncObject,
+        `${cmd} didn't modify its input`
+      )
     } else if (parsed) {
       t.throws(() => {
         parsed.inc(what, id)


### PR DESCRIPTION
<!-- What / Why -->
`inc` can be used three ways:
 1.  As a an option on the CLI : `npx semver 1.0.0 -i major`
 2.  As a method of the `SemVer` class: `semverInstance.inc('major')`
 3.  As a function: `inc('1.0.0', 'major')`
 
 This PR does not impact the behaviour of the first two and focuses only on the last one.
 
 The underlying issue is described in #425, but tl;dr `inc` should be a pure function (I think, from its documentation on NPM), and here it has a side-effect.
 
 I remove this side-effect by ensuring that the `SemVer` instance created inside the `inc` function is created from a string, which removes the mutation vector.

## References
  Depends on #426 - just to fix the tests, that's why https://github.com/npm/node-semver/commit/563d75e3b5c10ee72c3d05c38c55c8a0e6c83c98 is polluting the changeset
  Fixes #425 
