### PR TITLE
fix: properly escape dots in `GTE0` regexes

### DIFF
--- a/internal/re.js
+++ b/internal/re.js
@@ -10,7 +10,7 @@ let R = 0
 
 const createToken = (name, value, isGlobal) => {
   const index = R++
-  debug(index, value)
+  debug(name, index, value)
   t[name] = index
   src[index] = value
   re[index] = new RegExp(value, isGlobal ? 'g' : undefined)
@@ -178,5 +178,5 @@ createToken('HYPHENRANGELOOSE', `^\\s*(${src[t.XRANGEPLAINLOOSE]})` +
 // Star ranges basically just allow anything at all.
 createToken('STAR', '(<|>)?=?\\s*\\*')
 // >=0.0.0 is like a star
-createToken('GTE0', '^\\s*>=\\s*0\.0\.0\\s*$')
-createToken('GTE0PRE', '^\\s*>=\\s*0\.0\.0-0\\s*$')
+createToken('GTE0', '^\\s*>=\\s*0\\.0\\.0\\s*$')
+createToken('GTE0PRE', '^\\s*>=\\s*0\\.0\\.0-0\\s*$')

--- a/test/classes/range.js
+++ b/test/classes/range.js
@@ -17,9 +17,9 @@ test('range tests', t => {
 
 test('range parsing', t => {
   t.plan(rangeParse.length)
-  rangeParse.forEach(([range, expect, options]) => t.test(`${range} ${expect}`, t => {
+  rangeParse.forEach(([range, expect, options]) => t.test(`${range} ${expect} ${JSON.stringify(options)}`, t => {
     if (expect === null)
-      t.throws(() => new Range(range), TypeError, `invalid range: ${range}`)
+      t.throws(() => new Range(range, options), TypeError, `invalid range: ${range} ${JSON.stringify(options)}`)
     else {
       t.equal(new Range(range, options).range || '*', expect,
         `${range} => ${expect}`)

--- a/test/fixtures/range-parse.js
+++ b/test/fixtures/range-parse.js
@@ -89,4 +89,8 @@ module.exports = [
   ['<X', '<0.0.0-0'],
   ['<x <* || >* 2.x', '<0.0.0-0'],
   ['>x 2.x || * || <x', '*'],
+  ['>=09090', null],
+  ['>=09090', '>=9090.0.0', true],
+  ['>=09090-0', null, { includePrerelease: true }],
+  ['>=09090-0', null, { loose: true, includePrerelease: true }],
 ]

--- a/test/ranges/valid.js
+++ b/test/ranges/valid.js
@@ -8,5 +8,5 @@ test('valid range test', (t) => {
   t.plan(rangeParse.length)
   rangeParse.forEach(([pre, wanted, options]) =>
     t.equal(validRange(pre, options), wanted,
-      `validRange(${pre}) === ${wanted}`))
+      `validRange(${pre}) === ${wanted} ${JSON.stringify(options)}`))
 })


### PR DESCRIPTION
Previously the dots were not properly escaped causing them to match any
character. This caused ranges like `>=09090` to evaulate to `*` after
they were incorrectly matched by the `GTE0` regex. This only happened in
strict mode since in loose mode the leading 0 is allowed and parsed into
`>=9090.0.0` before the `GTE0` check. After this fix, this range now
will throw an error. This also affected prerelease versions in both
strict and loose mode.
