### PR TITLE
fix: replace regex used to split ranges

### DIFF
--- a/classes/range.js
+++ b/classes/range.js
@@ -29,7 +29,7 @@ class Range {
     // First, split based on boolean or ||
     this.raw = range
     this.set = range
-      .split(/\s*\|\|\s*/)
+      .split('||')
       // map the range to a 2d array of comparators
       .map(range => this.parseRange(range.trim()))
       // throw out any comparator lists that are empty


### PR DESCRIPTION
Found in #433, the regex used to split ranges on `||` was padded by `\s*`
on either side causing a decrease in performance when used on range
strings with a lot of spaces. Since the result of the split is
immediately trimmed, we can just split on the string instead.
