### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/test/map.js
+++ b/test/map.js
@@ -25,7 +25,7 @@ const find = (folder, set = [], root = true) => {
   if (!root) {
     return
   }
-  return set.map(f => f.substr(folder.length + 1)
+  return set.map(f => f.slice(folder.length + 1)
     .replace(/\\/g, '/'))
     .sort((a, b) => a.localeCompare(b))
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.