### PR TITLE
doc: add warning in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 semver(1) -- The semantic versioner for npm
 ===========================================
 
+> It is a special node implementation for NPM the RFC is not guarantee
+> 
+> As exemple leading `v` is consider as valid by `valid` method
+
 ## Install
 
 ```bash


### PR DESCRIPTION
Following this chat, https://github.com/npm/node-semver/issues/376
This adds to the README to prevent misleading usage of this package, for people like me who expect SemVer package follow the RCF and specifically this : https://semver.org/#is-v123-a-semantic-version
