### PR TITLE
[bug fix] trivial bug in hyphenReplace()

### DIFF
--- a/classes/range.js
+++ b/classes/range.js
@@ -465,7 +465,7 @@ const hyphenReplace = incPr => ($0,
   } else if (fpr) {
     from = `>=${from}`
   } else {
-    from = `>=${from}${incPr ? '-0' : ''}`
+    from = `>=${fM}.${fm}.${fp}${incPr ? '-0' : ''}`
   }
 
   if (isX(tM)) {


### PR DESCRIPTION
when incPr is true, '1.2.3+a - 4.5.6+b' is '>=1.2.3 <4.5.7-0' instead of '>=1.2.3-0 <4.5.7-0'
