### PR TITLE
perf: improving performance

### DIFF
--- a/classes/range.js
+++ b/classes/range.js
@@ -31,7 +31,7 @@ class Range {
     this.set = range
       .split('||')
       // map the range to a 2d array of comparators
-      .map(r => this.parseRange(r.trim()))
+      .map(r => this.parseRange(r))
       // throw out any comparator lists that are empty
       // this generally means that it was not a valid range, which is allowed
       // in loose mode, but will still throw if the WHOLE range is invalid.
@@ -81,8 +81,8 @@ class Range {
 
     // memoize range parsing for performance.
     // this is a very hot path, and fully deterministic.
-    const memoOpts = Object.keys(this.options).join(',')
-    const memoKey = `parseRange:${memoOpts}:${range}`
+    const memoOpts = buildMemoKeyFromOptions(this.options)
+    const memoKey = memoOpts + range
     const cached = cache.get(memoKey)
     if (cached) {
       return cached
@@ -190,6 +190,35 @@ class Range {
     return false
   }
 }
+
+function buildMemoKeyFromOptions(options) {
+  if (options.includePrerelease === true) {
+    if (options.loose === true && options.rtl === true) {
+      return '1';
+    }
+
+    if (options.loose === true) {
+      return '2';
+    }
+  
+    if (options.rtl === true) {
+      return '3';
+    }
+
+    return '4';
+  } else if (options.loose === true) {
+    if (options.rtl === true) {
+      return '5';
+    }
+
+    return '6';
+  } else if (options.rtl === true) {
+    return '7';
+  } else {
+    return '8';
+  }
+}
+
 module.exports = Range
 
 const LRU = require('lru-cache')

--- a/internal/parse-options.js
+++ b/internal/parse-options.js
@@ -1,11 +1,17 @@
-// parse out just the options we care about so we always get a consistent
-// obj with keys in a consistent order.
-const opts = ['includePrerelease', 'loose', 'rtl']
-const parseOptions = options =>
-  !options ? {}
-  : typeof options !== 'object' ? { loose: true }
-  : opts.filter(k => options[k]).reduce((o, k) => {
-    o[k] = true
-    return o
-  }, {})
-module.exports = parseOptions
+const parseOptions = options => {
+  if (!options) return {};
+
+  if (typeof options !== 'object') return { loose: true };
+
+  const parsedOptions = {};
+
+  // parse out just the options we care about so we always get a consistent
+  // obj with keys in a consistent order.
+
+  if (options.includePrerelease) parsedOptions.includePrerelease = true;
+  if (options.loose) parsedOptions.loose = true;
+  if (options.rtl) parsedOptions.rtl = true;
+
+  return parsedOptions;
+};
+module.exports = parseOptions;

--- a/internal/parse-options.js
+++ b/internal/parse-options.js
@@ -1,17 +1,41 @@
+const var1 = Object.freeze({ includePrerelease: true, loose: true, rtl: true });
+const var2 = Object.freeze({ includePrerelease: true, loose: true });
+const var3 = Object.freeze({ includePrerelease: true, rtl: true });
+const var4 = Object.freeze({ includePrerelease: true });
+const var5 = Object.freeze({ loose: true, rtl: true });
+const var6 = Object.freeze({ loose: true });
+const var7 = Object.freeze({ rtl: true });
+const emptyOpts = Object.freeze({});
+
 const parseOptions = options => {
-  if (!options) return {};
+  if (!options) return emptyOpts;
 
-  if (typeof options !== 'object') return { loose: true };
+  if (typeof options !== 'object') return var6;
 
-  const parsedOptions = {};
+  if (options.includePrerelease) {
+    if (options.loose && options.rtl) {
+      return var1;
+    }
 
-  // parse out just the options we care about so we always get a consistent
-  // obj with keys in a consistent order.
+    if (options.loose) {
+      return var2;
+    }
 
-  if (options.includePrerelease) parsedOptions.includePrerelease = true;
-  if (options.loose) parsedOptions.loose = true;
-  if (options.rtl) parsedOptions.rtl = true;
+    if (options.rtl) {
+      return var3;
+    }
 
-  return parsedOptions;
+    return var4;
+  } else if (options.loose) {
+    if (options.rtl) {
+      return var5;
+    }
+
+    return var6;
+  } else if (options.rtl) {
+    return var7;
+  } else {
+    return emptyOpts;
+  }
 };
 module.exports = parseOptions;


### PR DESCRIPTION
<!-- What / Why -->
I saw [this tweet](https://twitter.com/andhaveaniceday/status/1641559475684528128) by @jakebailey, describing the time spent just parsing the options.

<!-- Describe the request in detail. What it does and why it's being changed. -->

## parsing-options.js

So I did a simple refactoring removing two loops from the parsing options, before:

```md
includePrerelease x 14,044,087 ops/sec ±3.19% (87 runs sampled)
includePrerelease + loose x 7,062,745 ops/sec ±1.14% (86 runs sampled)
includePrerelease + loose + rtl x 7,210,500 ops/sec ±1.41% (89 runs sampled)
```

After:

```md
includePrerelease x 1,107,553,453 ops/sec ±1.07% (93 runs sampled)
includePrerelease + loose x 1,119,018,905 ops/sec ±0.16% (88 runs sampled)
includePrerelease + loose + rtl x 1,126,801,317 ops/sec ±0.15% (89 runs sampled)
```

<details>
<summary>benchmark.js</summary>

```js
const Benchmark = require('benchmark')
const parseOptions = require('./internal/parse-options');
const suite = new Benchmark.Suite;

const options1 = {
  includePrerelease: true,
};

const options2 = {
  includePrerelease: true,
  loose: true,
};

const options3 = {
  includePrerelease: true,
  loose: true,
  rtl: false,
};

suite
.add('includePrerelease', function () {
  parseOptions(options1);
})
.add('includePrerelease + loose', function () {
  parseOptions(options2);
})
.add('includePrerelease + loose + rtl', function () {
  parseOptions(options3);
})
.on('cycle', function(event) {
  console.log(String(event.target))
})
.run({ 'async': false });
```

</details>

## range.js

Inside range.js, I saw this piece of code:

https://github.com/npm/node-semver/blob/da08e01cd96f9d70a8b4fbc7dc3f69eef930f67a/classes/range.js#L84

`Object.keys` is not the fastest method, so I create a function to simply return a key depending of the options.

Before:

```md
bject.keys({"includePrelease":true}).join(',') x 13,643,510 ops/sec ±3.43% (81 runs sampled)
Object.keys({"includePrelease":true,"loose":true}).join(',') x 7,877,215 ops/sec ±1.57% (92 runs sampled)
Object.keys({"includePrelease":true,"loose":true,"rtl":true}).join(',') x 5,786,808 ops/sec ±1.09% (94 runs sampled)
```

After:

```md
buildMemoKeyFromOptions({"includePrelease":true}) x 1,128,743,301 ops/sec ±0.03% (96 runs sampled)
buildMemoKeyFromOptions({"includePrelease":true,"loose":true}) x 1,115,671,401 ops/sec ±0.87% (95 runs sampled)
buildMemoKeyFromOptions({"includePrelease":true,"loose":true,"rtl":true}) x 1,101,585,690 ops/sec ±1.59% (90 runs sampled)
```

<details>

<summary>benchmark.js</summary>

```js
const Benchmark = require('benchmark');
const suite = new Benchmark.Suite();

const option1 = { includePrelease: true };
const option2 = { includePrelease: true, loose: true };
const option3 = { includePrelease: true, loose: true, rtl: true };

function buildMemoKeyFromOptions(options) {
  if (options.includePrerelease === true) {
    if (options.loose === true && options.rtl === true) {
      return '1';
    }

    if (options.loose === true) {
      return '2';
    }

    if (options.rtl === true) {
      return '3';
    }

    return '4';
  } else if (options.loose === true) {
    if (options.rtl === true) {
      return '5';
    }

    return '6';
  } else if (options.rtl === true) {
    return '7';
  } else {
    return '8';
  }
}

suite
  .add(`Object.keys(${JSON.stringify(option1)}).join(',')`, function () {
    Object.keys(option1).join(',');
  })
  .add(`Object.keys(${JSON.stringify(option2)}).join(',')`, function () {
    Object.keys(option2).join(',');
  })
  .add(`Object.keys(${JSON.stringify(option3)}).join(',')`, function () {
    Object.keys(option3).join(',');
  });

suite
  .add(`buildMemoKeyFromOptions(${JSON.stringify(option1)})`, function () {
    buildMemoKeyFromOptions(option1);
  })
  .add(`buildMemoKeyFromOptions(${JSON.stringify(option2)})`, function () {
    buildMemoKeyFromOptions(option2);
  })
  .add(`buildMemoKeyFromOptions(${JSON.stringify(option3)})`, function () {
    buildMemoKeyFromOptions(option3);
  });

suite
  .on('cycle', function (event) {
    console.log(String(event.target));
  })
  .run({ async: false });
```

</details>

When we compare the performance improvements on `satisfies` function:

Before:

```md
satisfies(1.0.6, 1.0.3||^2.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 219,080 ops/sec ±0.98% (94 runs sampled)
satisfies(1.0.6, 2.2.2||~3.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 226,188 ops/sec ±1.00% (91 runs sampled)
satisfies(1.0.6, 2.3.0||<4.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 236,135 ops/sec ±1.10% (90 runs sampled)
```

After:

```md
satisfies(1.0.6, 1.0.3||^2.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 382,478 ops/sec ±0.80% (95 runs sampled)
satisfies(1.0.6, 2.2.2||~3.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 404,203 ops/sec ±0.85% (97 runs sampled)
satisfies(1.0.6, 2.3.0||<4.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 429,043 ops/sec ±0.78% (91 runs sampled)
```

<details>

<summary>benchmark.js</summary>

```js
const Benchmark = require('benchmark');
const satisfies = require('./functions/satisfies');
const suite = new Benchmark.Suite();

const versions = ['1.0.3||^2.0.0', '2.2.2||~3.0.0', '2.3.0||<4.0.0'];
const versionToCompare = '1.0.6';
const option1 = { includePrelease: true };
const option2 = { includePrelease: true, loose: true };
const option3 = { includePrelease: true, loose: true, rtl: true };

for (const version of versions) {
  suite.add(`satisfies(${versionToCompare}, ${version})`, function () {
    satisfies(versionToCompare, version);
  });
}

for (const version of versions) {
  suite.add(`satisfies(${versionToCompare}, ${version}, ${JSON.stringify(option1)})`, function () {
    satisfies(versionToCompare, version, option1);
  });
}

for (const version of versions) {
  suite.add(`satisfies(${versionToCompare}, ${version}, ${JSON.stringify(option2)})`, function () {
    satisfies(versionToCompare, version, option2);
  });
}

for (const version of versions) {
  suite.add(`satisfies(${versionToCompare}, ${version}, ${JSON.stringify(option3)})`, function () {
    satisfies(versionToCompare, version, option3);
  });
}
suite
  .on('cycle', function (event) {
    console.log(String(event.target));
  })
  .run({ async: false });
```

</details>

> I will keep as draft for now because I want to see if I can find more optimizations.