### PR TITLE
fix: faster parse options

### DIFF
--- a/bin/semver.js
+++ b/bin/semver.js
@@ -24,6 +24,7 @@ let rtl = false
 let identifier
 
 const semver = require('../')
+const parseOptions = require('../internal/parse-options')
 
 let reverse = false
 
@@ -88,7 +89,7 @@ const main = () => {
     }
   }
 
-  options = { loose: loose, includePrerelease: includePrerelease, rtl: rtl }
+  options = parseOptions({ loose, includePrerelease, rtl })
 
   versions = versions.map((v) => {
     return coerce ? (semver.coerce(v, options) || { version: v }).version : v

--- a/classes/comparator.js
+++ b/classes/comparator.js
@@ -78,13 +78,6 @@ class Comparator {
       throw new TypeError('a Comparator is required')
     }
 
-    if (!options || typeof options !== 'object') {
-      options = {
-        loose: !!options,
-        includePrerelease: false,
-      }
-    }
-
     if (this.operator === '') {
       if (this.value === '') {
         return true

--- a/functions/parse.js
+++ b/functions/parse.js
@@ -4,8 +4,6 @@ const SemVer = require('../classes/semver')
 
 const parseOptions = require('../internal/parse-options')
 const parse = (version, options) => {
-  options = parseOptions(options)
-
   if (version instanceof SemVer) {
     return version
   }
@@ -18,6 +16,7 @@ const parse = (version, options) => {
     return null
   }
 
+  options = parseOptions(options)
   const r = options.loose ? re[t.LOOSE] : re[t.FULL]
   if (!r.test(version)) {
     return null

--- a/internal/parse-options.js
+++ b/internal/parse-options.js
@@ -1,11 +1,51 @@
-// parse out just the options we care about so we always get a consistent
-// obj with keys in a consistent order.
-const opts = ['includePrerelease', 'loose', 'rtl']
-const parseOptions = options =>
-  !options ? {}
-  : typeof options !== 'object' ? { loose: true }
-  : opts.filter(k => options[k]).reduce((o, k) => {
-    o[k] = true
-    return o
-  }, {})
+// parse out just the options we care about
+const isParsedConfigSymbol = Symbol('isParsedConfig')
+const var1 = Object.freeze({ includePrerelease: true, loose: true, rtl: true, [isParsedConfigSymbol]: true })
+const var2 = Object.freeze({ includePrerelease: true, loose: true, [isParsedConfigSymbol]: true })
+const var3 = Object.freeze({ includePrerelease: true, rtl: true, [isParsedConfigSymbol]: true })
+const var4 = Object.freeze({ includePrerelease: true, [isParsedConfigSymbol]: true })
+const var5 = Object.freeze({ loose: true, rtl: true, [isParsedConfigSymbol]: true })
+const var6 = Object.freeze({ loose: true, [isParsedConfigSymbol]: true })
+const var7 = Object.freeze({ rtl: true, [isParsedConfigSymbol]: true })
+const emptyOpts = Object.freeze({ [isParsedConfigSymbol]: true })
+
+const parseOptions = options => {
+  if (!options) {
+    return emptyOpts
+  }
+
+  if (typeof options !== 'object') {
+    return var6
+  }
+
+  if (options[isParsedConfigSymbol]) {
+    return options
+  }
+
+  if (options.includePrerelease) {
+    if (options.loose && options.rtl) {
+      return var1
+    }
+
+    if (options.loose) {
+      return var2
+    }
+
+    if (options.rtl) {
+      return var3
+    }
+
+    return var4
+  } else if (options.loose) {
+    if (options.rtl) {
+      return var5
+    }
+
+    return var6
+  } else if (options.rtl) {
+    return var7
+  } else {
+    return emptyOpts
+  }
+}
 module.exports = parseOptions

--- a/internal/parse-options.js
+++ b/internal/parse-options.js
@@ -1,51 +1,15 @@
 // parse out just the options we care about
-const isParsedConfigSymbol = Symbol('isParsedConfig')
-const var1 = Object.freeze({ includePrerelease: true, loose: true, rtl: true, [isParsedConfigSymbol]: true })
-const var2 = Object.freeze({ includePrerelease: true, loose: true, [isParsedConfigSymbol]: true })
-const var3 = Object.freeze({ includePrerelease: true, rtl: true, [isParsedConfigSymbol]: true })
-const var4 = Object.freeze({ includePrerelease: true, [isParsedConfigSymbol]: true })
-const var5 = Object.freeze({ loose: true, rtl: true, [isParsedConfigSymbol]: true })
-const var6 = Object.freeze({ loose: true, [isParsedConfigSymbol]: true })
-const var7 = Object.freeze({ rtl: true, [isParsedConfigSymbol]: true })
-const emptyOpts = Object.freeze({ [isParsedConfigSymbol]: true })
-
+const looseOption = Object.freeze({ loose: true })
+const emptyOpts = Object.freeze({ })
 const parseOptions = options => {
   if (!options) {
     return emptyOpts
   }
 
   if (typeof options !== 'object') {
-    return var6
+    return looseOption
   }
 
-  if (options[isParsedConfigSymbol]) {
-    return options
-  }
-
-  if (options.includePrerelease) {
-    if (options.loose && options.rtl) {
-      return var1
-    }
-
-    if (options.loose) {
-      return var2
-    }
-
-    if (options.rtl) {
-      return var3
-    }
-
-    return var4
-  } else if (options.loose) {
-    if (options.rtl) {
-      return var5
-    }
-
-    return var6
-  } else if (options.rtl) {
-    return var7
-  } else {
-    return emptyOpts
-  }
+  return options
 }
 module.exports = parseOptions

--- a/test/internal/parse-options.js
+++ b/test/internal/parse-options.js
@@ -27,5 +27,20 @@ t.test('objects only include truthy flags we know about, set to true', t => {
     rtl: true,
     includePrerelease: true,
   })
+  t.strictSame(parseOptions({ loose: true }), { loose: true })
+  t.strictSame(parseOptions({ rtl: true }), { rtl: true })
+  t.strictSame(parseOptions({ includePrerelease: true }), { includePrerelease: true })
+  t.strictSame(parseOptions({ loose: true, rtl: true }), { loose: true, rtl: true })
+  t.strictSame(parseOptions({ loose: true, includePrerelease: true }), { loose: true, includePrerelease: true })
+  t.strictSame(parseOptions({ rtl: true, includePrerelease: true }), { rtl: true, includePrerelease: true })
+  t.end()
+})
+
+t.test('should skip validation when options is already parsed', t => {
+  const options = { loose: true, rtl: true }
+  const parsedOptions = parseOptions(options)
+
+  t.equal(parseOptions(parsedOptions) === parsedOptions, true)
+  t.not(parseOptions(options) === parsedOptions, false)
   t.end()
 })

--- a/test/internal/parse-options.js
+++ b/test/internal/parse-options.js
@@ -18,29 +18,26 @@ t.test('truthy non-objects always loose mode, for backwards comp', t => {
   t.end()
 })
 
-t.test('objects only include truthy flags we know about, set to true', t => {
-  t.strictSame(parseOptions(/asdf/), {})
-  t.strictSame(parseOptions(new Error('hello')), {})
-  t.strictSame(parseOptions({ loose: true, a: 1, rtl: false }), { loose: true })
+t.test('any object passed is returned', t => {
+  t.strictSame(parseOptions(/asdf/), /asdf/)
+  t.strictSame(parseOptions(new Error('hello')), new Error('hello'))
+  t.strictSame(parseOptions({ loose: true, a: 1, rtl: false }), { loose: true, a: 1, rtl: false })
   t.strictSame(parseOptions({ loose: 1, rtl: 2, includePrerelease: 10 }), {
-    loose: true,
-    rtl: true,
-    includePrerelease: true,
+    loose: 1,
+    rtl: 2,
+    includePrerelease: 10,
   })
   t.strictSame(parseOptions({ loose: true }), { loose: true })
   t.strictSame(parseOptions({ rtl: true }), { rtl: true })
   t.strictSame(parseOptions({ includePrerelease: true }), { includePrerelease: true })
   t.strictSame(parseOptions({ loose: true, rtl: true }), { loose: true, rtl: true })
-  t.strictSame(parseOptions({ loose: true, includePrerelease: true }), { loose: true, includePrerelease: true })
-  t.strictSame(parseOptions({ rtl: true, includePrerelease: true }), { rtl: true, includePrerelease: true })
-  t.end()
-})
-
-t.test('should skip validation when options is already parsed', t => {
-  const options = { loose: true, rtl: true }
-  const parsedOptions = parseOptions(options)
-
-  t.equal(parseOptions(parsedOptions) === parsedOptions, true)
-  t.not(parseOptions(options) === parsedOptions, false)
+  t.strictSame(parseOptions({ loose: true, includePrerelease: true }), {
+    loose: true,
+    includePrerelease: true,
+  })
+  t.strictSame(parseOptions({ rtl: true, includePrerelease: true }), {
+    rtl: true,
+    includePrerelease: true,
+  })
   t.end()
 })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

The performance of parse-options before:

```
includePrerelease x 12,935,785 ops/sec ±3.66% (80 runs sampled)
includePrerelease + loose x 6,915,009 ops/sec ±1.54% (85 runs sampled)
includePrerelease + loose + rtl x 7,350,781 ops/sec ±1.54% (88 runs sampled)
```

After:

```
includePrerelease x 1,122,022,296 ops/sec ±0.81% (96 runs sampled)
includePrerelease + loose x 1,133,747,998 ops/sec ±0.11% (89 runs sampled)
includePrerelease + loose + rtl x 1,135,218,097 ops/sec ±0.35% (95 runs sampled)
```

The performance improvement also extend for any method that use `parseOptions`, like `satisfies`:

Before:

```
satisfies(1.0.6, 1.0.3||^2.0.0) x 281,862 ops/sec ±2.84% (89 runs sampled)
satisfies(1.0.6, 2.2.2||~3.0.0) x 312,593 ops/sec ±0.90% (95 runs sampled)
satisfies(1.0.6, 2.3.0||<4.0.0) x 323,066 ops/sec ±1.15% (89 runs sampled)
satisfies(1.0.6, 1.0.3||^2.0.0, {"includePrelease":true}) x 275,542 ops/sec ±1.24% (91 runs sampled)
satisfies(1.0.6, 2.2.2||~3.0.0, {"includePrelease":true}) x 295,613 ops/sec ±1.07% (94 runs sampled)
satisfies(1.0.6, 2.3.0||<4.0.0, {"includePrelease":true}) x 314,728 ops/sec ±1.22% (90 runs sampled)
satisfies(1.0.6, 1.0.3||^2.0.0, {"includePrelease":true,"loose":true}) x 253,795 ops/sec ±0.93% (94 runs sampled)
satisfies(1.0.6, 2.2.2||~3.0.0, {"includePrelease":true,"loose":true}) x 268,212 ops/sec ±1.18% (95 runs sampled)
satisfies(1.0.6, 2.3.0||<4.0.0, {"includePrelease":true,"loose":true}) x 280,362 ops/sec ±1.18% (94 runs sampled)
satisfies(1.0.6, 1.0.3||^2.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 218,464 ops/sec ±2.21% (90 runs sampled)
satisfies(1.0.6, 2.2.2||~3.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 232,007 ops/sec ±1.05% (91 runs sampled)
satisfies(1.0.6, 2.3.0||<4.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 244,718 ops/sec ±0.90% (94 runs sampled)
```

Then:

```
satisfies(1.0.6, 1.0.3||^2.0.0) x 323,247 ops/sec ±1.44% (90 runs sampled)
satisfies(1.0.6, 2.2.2||~3.0.0) x 335,885 ops/sec ±1.22% (92 runs sampled)
satisfies(1.0.6, 2.3.0||<4.0.0) x 358,881 ops/sec ±0.89% (96 runs sampled)
satisfies(1.0.6, 1.0.3||^2.0.0, {"includePrelease":true}) x 321,664 ops/sec ±0.85% (94 runs sampled)
satisfies(1.0.6, 2.2.2||~3.0.0, {"includePrelease":true}) x 341,290 ops/sec ±1.00% (96 runs sampled)
satisfies(1.0.6, 2.3.0||<4.0.0, {"includePrelease":true}) x 367,722 ops/sec ±0.95% (96 runs sampled)
satisfies(1.0.6, 1.0.3||^2.0.0, {"includePrelease":true,"loose":true}) x 294,952 ops/sec ±0.56% (93 runs sampled)
satisfies(1.0.6, 2.2.2||~3.0.0, {"includePrelease":true,"loose":true}) x 311,517 ops/sec ±0.36% (94 runs sampled)
satisfies(1.0.6, 2.3.0||<4.0.0, {"includePrelease":true,"loose":true}) x 320,496 ops/sec ±1.18% (91 runs sampled)
satisfies(1.0.6, 1.0.3||^2.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 274,429 ops/sec ±0.58% (94 runs sampled)
satisfies(1.0.6, 2.2.2||~3.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 282,862 ops/sec ±0.72% (91 runs sampled)
satisfies(1.0.6, 2.3.0||<4.0.0, {"includePrelease":true,"loose":true,"rtl":true}) x 304,038 ops/sec ±0.44% (94 runs sampled)
```

I also added parseOptions before any method that passes `options` down to range or semver to reduce the number of comparisons by looking into `isParsedConfigSymbol`.

With this new way of parsing the options, the memory allocation is 0 for any parsed options.

The only downside is the maintenance, the number of variables to represent the options can increase depending on the number of options if we keep just 3 options, so is not a problem, if we add more, is more comparisons.

### Alternative Version

I also made a version using bit masks, which you can see in this commit: https://github.com/h4ad-forks/node-semver/commit/6c7a68ad9849cadbc624ef5208662ae1ea01d846

In that version, the performance benefits are the same, the maintenance is lower because is very easy to handle bit flags but is takes more memory and breaks one test of parse-options (about the number).

Also, the options now are just a getter and I introduce a new variable called `flagOptions`, which holds all the flags.

## Conclusion

In terms of lower changes and lower memory usage, the best option is `Object.freeze`.

If you want to take more aggressive changes with lower maintenance in the future and allocating some memory in the process, the option with bit masks is the best.

## References

Related to #528

<details>
<summary>benchmark.js</summary>

```js
const Benchmark = require('benchmark');
const satisfies = require('./functions/satisfies');
const suite = new Benchmark.Suite();

const versions = ['1.0.3||^2.0.0', '2.2.2||~3.0.0', '2.3.0||<4.0.0'];
const versionToCompare = '1.0.6';
const option1 = { includePrelease: true };
const option2 = { includePrelease: true, loose: true };
const option3 = { includePrelease: true, loose: true, rtl: true };

for (const version of versions) {
  suite.add(`satisfies(${versionToCompare}, ${version})`, function () {
    satisfies(versionToCompare, version);
  });
}

for (const version of versions) {
  suite.add(`satisfies(${versionToCompare}, ${version}, ${JSON.stringify(option1)})`, function () {
    satisfies(versionToCompare, version, option1);
  });
}

for (const version of versions) {
  suite.add(`satisfies(${versionToCompare}, ${version}, ${JSON.stringify(option2)})`, function () {
    satisfies(versionToCompare, version, option2);
  });
}

for (const version of versions) {
  suite.add(`satisfies(${versionToCompare}, ${version}, ${JSON.stringify(option3)})`, function () {
    satisfies(versionToCompare, version, option3);
  });
}

suite
  .on('cycle', function (event) {
    console.log(String(event.target));
  })
  .run({ async: false });
```

</details/>

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
