### PR TITLE
fix: reuse comparators on subset

### DIFF
--- a/ranges/subset.js
+++ b/ranges/subset.js
@@ -68,6 +68,9 @@ const subset = (sub, dom, options = {}) => {
   return true
 }
 
+const minimumVersionWithPreRelease = [new Comparator('>=0.0.0-0')]
+const minimumVersion = [new Comparator('>=0.0.0')]
+
 const simpleSubset = (sub, dom, options) => {
   if (sub === dom) {
     return true
@@ -77,9 +80,9 @@ const simpleSubset = (sub, dom, options) => {
     if (dom.length === 1 && dom[0].semver === ANY) {
       return true
     } else if (options.includePrerelease) {
-      sub = [new Comparator('>=0.0.0-0')]
+      sub = minimumVersionWithPreRelease
     } else {
-      sub = [new Comparator('>=0.0.0')]
+      sub = minimumVersion
     }
   }
 
@@ -87,7 +90,7 @@ const simpleSubset = (sub, dom, options) => {
     if (options.includePrerelease) {
       return true
     } else {
-      dom = [new Comparator('>=0.0.0')]
+      dom = minimumVersion
     }
   }
 


### PR DESCRIPTION
<!-- What / Why -->
As I comment here: https://github.com/npm/node-semver/pull/528#issuecomment-1499241387

The method of subset was creating comparators without needing for a specific ranges, perf:

```
subset(1.2.3, *) x 208,363 ops/sec ±1.01% (93 runs sampled)
subset(^1.2.3, *) x 238,678 ops/sec ±1.08% (91 runs sampled)
subset(^1.2.3-pre.0, *) x 235,344 ops/sec ±1.12% (92 runs sampled)
subset(^1.2.3-pre.0, *) x 238,530 ops/sec ±0.97% (96 runs sampled)
subset(1 || 2 || 3, *) x 117,125 ops/sec ±0.83% (93 runs sampled)
```

After caching those comparators:

```
subset(1.2.3, *) x 241,957 ops/sec ±0.78% (93 runs sampled)
subset(^1.2.3, *) x 277,689 ops/sec ±1.02% (93 runs sampled)
subset(^1.2.3-pre.0, *) x 278,444 ops/sec ±1.29% (95 runs sampled)
subset(^1.2.3-pre.0, *) x 278,750 ops/sec ±0.99% (94 runs sampled)
subset(1 || 2 || 3, *) x 145,633 ops/sec ±1.66% (92 runs sampled)
```

It's an improvement of about 13~14% for these cases.

<details>
<summary>benchmark.js</summary>

```js
const Benchmark = require('benchmark')
const subset = require('./ranges/subset')
const suite = new Benchmark.Suite()

// taken from tests
const cases = [
  // everything is a subset of *
  ['1.2.3', '*', true],
  ['^1.2.3', '*', true],
  ['^1.2.3-pre.0', '*', false],
  ['^1.2.3-pre.0', '*', true, { includePrerelease: true }],
  ['1 || 2 || 3', '*', true],
]

for (const [sub, dom] of cases) {
  suite.add(`subset(${sub}, ${dom})`, function () {
    subset(sub, dom)
  })
}

suite
  .on('cycle', function (event) {
    console.log(String(event.target))
  })
  .run({ async: false })
```

</details/>

## About memory

To test the memory usage, I used [isitfast](https://github.com/yamiteru/isitfast) which still in beta but provide a useful way of measuring memory (ignore op/s):

```before:
subset(1.2.3, *) 71,597 op/s (13,967 ns) ±1% x2,500 | 3,640 kB ±0.1% x25
subset(^1.2.3, *) 100,210 op/s (9,979 ns) ±1% x2,500 | 3,648 kB ±0.1% x25
subset(^1.2.3-pre.0, *) 127,796 op/s (7,825 ns) ±1% x2,500 | 4,088 kB ±0.1% x25
subset(1 || 2 || 3, *) 81,340 op/s (12,294 ns) ±1% x2,500 | 8,976 kB ±0.06% x25
```

After:

```
subset(1.2.3, *) 88,324 op/s (11,322 ns) ±1% x2,500 | 2,856 kB ±0.2% x25
subset(^1.2.3, *) 129,433 op/s (7,726 ns) ±1% x2,500 | 2,864 kB ±0.2% x25
subset(^1.2.3-pre.0, *) 169,176 op/s (5,911 ns) ±1% x2,500 | 2,872 kB ±0.2% x25
subset(1 || 2 || 3, *) 96,899 op/s (10,320 ns) ±1% x2,500 | 6,624 kB ±0.08% x25
```

Is a reduction of 21%~26% in memory usage.

<details>
<summary>isitfast.js</summary>

```js
const { suite, useTerminalCompact } = require('isitfast')

const subset = require('./ranges/subset')

const benchmark = suite('Test', {
  gc: {
    allow: true,
  },
})

// taken from tests
const cases = [
  // everything is a subset of *
  ['1.2.3', '*', true],
  ['^1.2.3', '*', true],
  ['^1.2.3-pre.0', '*', false],
  ['^1.2.3-pre.0', '*', true, { includePrerelease: true }],
  ['1 || 2 || 3', '*', true],
]

for (const [sub, dom] of cases) {
  benchmark.add(`subset(${sub}, ${dom})`, function () {
    subset(sub, dom)
  })
}

useTerminalCompact();

benchmark.run();
```

<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
