### PR TITLE
fix: avoid re-instantiating SemVer during diff compare

### DIFF
--- a/functions/diff.js
+++ b/functions/diff.js
@@ -1,10 +1,9 @@
 const parse = require('./parse')
-const eq = require('./eq')
 
 const diff = (version1, version2) => {
   const v1 = parse(version1)
   const v2 = parse(version2)
-  if (eq(v1, v2)) {
+  if (v1.compare(v2) === 0) {
     return null
   } else {
     const hasPre = v1.prerelease.length || v2.prerelease.length


### PR DESCRIPTION

Following https://github.com/npm/node-semver/pull/539 this small change improves speed by ~10% just calling `compare` directly on the semver object returned by parse

Performance on branch v7.4.0
```
╭─macno@cayenne ~/Projects/opensource/node-semver  ‹v7.4.0›
╰─➤  node benchmark.js
diff(0.0.1, 0.0.1) x 4,290,326 ops/sec ±0.34% (95 runs sampled)
diff(0.0.1, 0.0.1-pre) x 2,136,948 ops/sec ±0.06% (94 runs sampled)
diff(0.0.1, 0.0.1-pre-2) x 2,123,307 ops/sec ±0.12% (95 runs sampled)
diff(1.1.0, 1.1.0-pre) x 2,124,436 ops/sec ±0.12% (102 runs sampled)
```

And after the change
```
╭─macno@cayenne ~/Projects/opensource/node-semver  ‹main›
╰─➤  node benchmark.js
diff(0.0.1, 0.0.1) x 4,801,698 ops/sec ±0.30% (90 runs sampled)
diff(0.0.1, 0.0.1-pre) x 2,323,553 ops/sec ±0.06% (98 runs sampled)
diff(0.0.1, 0.0.1-pre-2) x 2,307,169 ops/sec ±0.14% (98 runs sampled)
diff(1.1.0, 1.1.0-pre) x 2,319,211 ops/sec ±0.11% (95 runs sampled)
```

<details>
  <summary>benchmark.js</summary>

```js
const Benchmark = require('benchmark')
const diff = require('./functions/diff')
const suite = new Benchmark.Suite()

const cases = [
  ['0.0.1', '0.0.1', null ],
  ['0.0.1', '0.0.1-pre', 'patch'],
  ['0.0.1', '0.0.1-pre-2', 'patch'],
  ['1.1.0', '1.1.0-pre', 'minor'],
]

for (const [v1, v2] of cases) {
  suite.add(`diff(${v1}, ${v2})`, function () {
    diff(v1, v2)
  })
}

suite
  .on('cycle', function (event) {
    console.log(String(event.target))
  })
  .run({ async: false })
```

</details>

