### PR TITLE
fix: throw on bad version with correct error message

### DIFF
--- a/classes/semver.js
+++ b/classes/semver.js
@@ -16,7 +16,7 @@ class SemVer {
         version = version.version
       }
     } else if (typeof version !== 'string') {
-      throw new TypeError(`Invalid Version: ${version}`)
+      throw new TypeError(`Invalid Version: ${require('util').inspect(version)}`)
     }
 
     if (version.length > MAX_LENGTH) {

--- a/functions/diff.js
+++ b/functions/diff.js
@@ -1,8 +1,8 @@
-const parse = require('./parse')
+const parse = require('./parse.js')
 
 const diff = (version1, version2) => {
-  const v1 = parse(version1)
-  const v2 = parse(version2)
+  const v1 = parse(version1, null, true)
+  const v2 = parse(version2, null, true)
   const comparison = v1.compare(v2)
 
   if (comparison === 0) {

--- a/functions/parse.js
+++ b/functions/parse.js
@@ -1,22 +1,15 @@
-const { MAX_LENGTH } = require('../internal/constants')
 const SemVer = require('../classes/semver')
-const parse = (version, options) => {
+const parse = (version, options, throwErrors = false) => {
   if (version instanceof SemVer) {
     return version
   }
-
-  if (typeof version !== 'string') {
-    return null
-  }
-
-  if (version.length > MAX_LENGTH) {
-    return null
-  }
-
   try {
     return new SemVer(version, options)
   } catch (er) {
-    return null
+    if (!throwErrors) {
+      return null
+    }
+    throw er
   }
 }
 

--- a/test/functions/diff.js
+++ b/test/functions/diff.js
@@ -43,3 +43,13 @@ test('diff versions test', (t) => {
 
   t.end()
 })
+
+test('throws on bad version', (t) => {
+  t.throws(() => {
+    diff('bad', '1.2.3')
+  }, {
+    message: 'Invalid Version: bad',
+    name: 'TypeError',
+  })
+  t.end()
+})

--- a/test/functions/parse.js
+++ b/test/functions/parse.js
@@ -9,6 +9,22 @@ t.test('returns null instead of throwing when presented with garbage', t => {
     t.equal(parse(v, opts), null, msg))
 })
 
+t.test('throw errors if asked to', t => {
+  t.throws(() => {
+    parse('bad', null, true)
+  }, {
+    name: 'TypeError',
+    message: 'Invalid Version: bad',
+  })
+  t.throws(() => {
+    parse([], null, true)
+  }, {
+    name: 'TypeError',
+    message: 'Invalid Version: []',
+  })
+  t.end()
+})
+
 t.test('parse a version into a SemVer object', t => {
   t.match(parse('1.2.3'), new SemVer('1.2.3'))
   const s = new SemVer('4.5.6')


### PR DESCRIPTION
The parsing logic that is duplicated in SemVer's constructor was also removed.  See #541 for previous discussions about not optimizing for invalid SemVer.

With this fix:

```javascript
> semver.diff('foo', '1.2.3')
Uncaught TypeError: Invalid Version: foo
```

`v7.4.0`:

```javascript
> semver.diff('foo', '1.2.3')
Uncaught TypeError: Invalid Version: null
```

`503a4e52`:

```javscript
> semver.diff('foo', '1.2.3')
Uncaught TypeError: Cannot read properties of null (reading 'compare')
```