### PR TITLE
docs: add `pre` option for `inc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,8 +425,8 @@ strings that they parse.
     increments it.
   * If called from a prerelease version with `pre`, it increments the 
     revision number. Example: `inc('1.0.1-rc.1', 'pre') -> '1.0.1-rc.2'`
-    Be aware that `inc('1.0.0', 'pre') -> '1.0.0-0'` which is the wrong
-    direction.
+    Be aware that `inc('1.0.0', 'pre')` results in `1.0.0-0` which is 
+    the wrong direction.
 * `prerelease(v)`: Returns an array of prerelease components, or null
   if none exist. Example: `prerelease('1.2.3-alpha.1') -> ['alpha', 1]`
 * `major(v)`: Return the major version number.

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ strings that they parse.
 * `valid(v)`: Return the parsed version, or null if it's not valid.
 * `inc(v, release)`: Return the version incremented by the release
   type (`major`,   `premajor`, `minor`, `preminor`, `patch`,
-  `prepatch`, or `prerelease`), or null if it's not valid
+  `prepatch`, `prerelease`, or `pre`), or null if it's not valid
   * `premajor` in one call will bump the version up to the next major
     version and down to a prerelease of that major version.
     `preminor`, and `prepatch` work the same way.
@@ -423,6 +423,10 @@ strings that they parse.
     same as `prepatch`. It increments the patch version, then makes a
     prerelease. If the input version is already a prerelease it simply
     increments it.
+  * If called from a prerelease version with `pre`, it increments the 
+    revision number. Example: `inc('1.0.1-rc.1', 'pre') -> '1.0.1-rc.2'`
+    Be aware that `inc('1.0.0', 'pre') -> '1.0.0-0'` which is the wrong
+    direction.
 * `prerelease(v)`: Returns an array of prerelease components, or null
   if none exist. Example: `prerelease('1.2.3-alpha.1') -> ['alpha', 1]`
 * `major(v)`: Return the major version number.


### PR DESCRIPTION
Adds description of using `pre` with `inc` function with caveat that it might lead to unexpected results if version does not include a pre-release.

## References

Closes #124
