### PR TITLE
fix: correctly parse long build ids as valid

### DIFF
--- a/internal/re.js
+++ b/internal/re.js
@@ -1,4 +1,8 @@
-const { MAX_SAFE_COMPONENT_LENGTH, MAX_SAFE_BUILD_LENGTH } = require('./constants')
+const {
+  MAX_SAFE_COMPONENT_LENGTH,
+  MAX_SAFE_BUILD_LENGTH,
+  MAX_LENGTH,
+} = require('./constants')
 const debug = require('./debug')
 exports = module.exports = {}
 
@@ -19,7 +23,7 @@ const LETTERDASHNUMBER = '[a-zA-Z0-9-]'
 // all input should have extra whitespace removed.
 const safeRegexReplacements = [
   ['\\s', 1],
-  ['\\d', MAX_SAFE_COMPONENT_LENGTH],
+  ['\\d', MAX_LENGTH],
   [LETTERDASHNUMBER, MAX_SAFE_BUILD_LENGTH],
 ]
 

--- a/test/functions/valid.js
+++ b/test/functions/valid.js
@@ -2,6 +2,7 @@ const t = require('tap')
 const valid = require('../../functions/valid')
 const SemVer = require('../../classes/semver')
 const invalidVersions = require('../fixtures/invalid-versions')
+const { MAX_SAFE_INTEGER } = require('../../internal/constants')
 
 t.test('returns null instead of throwing when presented with garbage', t => {
   t.plan(invalidVersions.length)
@@ -15,5 +16,14 @@ t.test('validate a version into a SemVer object', t => {
   t.equal(valid(s), '4.5.6', 'return the version if a SemVer obj')
   t.equal(valid('4.2.0foo', true), '4.2.0-foo', 'looseness as a boolean')
   t.equal(valid('4.2.0foo', { loose: true }), '4.2.0-foo', 'looseness as an option')
+  t.end()
+})
+
+t.test('long build id', t => {
+  const longBuild = '-928490632884417731e7af463c92b034d6a78268fc993bcb88a57944'
+  const shortVersion = '1.1.1'
+  const longVersion = `${MAX_SAFE_INTEGER}.${MAX_SAFE_INTEGER}.${MAX_SAFE_INTEGER}`
+  t.equal(valid(shortVersion + longBuild), shortVersion + longBuild)
+  t.equal(valid(longVersion + longBuild), longVersion + longBuild)
   t.end()
 })


### PR DESCRIPTION
Fixes #580
