### PR TITLE
chore: add clean() test for build metadata

### DIFF
--- a/test/functions/clean.js
+++ b/test/functions/clean.js
@@ -17,6 +17,7 @@ test('clean tests', (t) => {
     ['~1.2.3', null],
     ['<=1.2.3', null],
     ['1.2.x', null],
+    ['0.12.0-dev.1150+3c22cecee', '0.12.0-dev.1150'],
   ].forEach(([range, version]) => {
     const msg = `clean(${range}) = ${version}`
     t.equal(clean(range), version, msg)


### PR DESCRIPTION
<!-- What / Why -->
Adds a test for `semver.clean` that demonstrates how the function strips build metadata.

<!-- Describe the request in detail. What it does and why it's being changed. -->

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
