### PR TITLE
feat: Add Semver.org regex as constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,18 @@ const semver = require('semver');
 console.log('We are currently using the semver specification version:', semver.SEMVER_SPEC_VERSION);
 ```
 
+### `SEMVER_REGEX`
+
+`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
+
+Source [here](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
+
+```
+const semver = require('semver');
+
+console.log('semver regex:', semver.SEMVER_REGEX);
+```
+
 ## Exported Modules
 
 <!--

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ module.exports = {
   re: internalRe.re,
   src: internalRe.src,
   tokens: internalRe.t,
+  SEMVER_REGEX: constants.SEMVER_REGEX,
   SEMVER_SPEC_VERSION: constants.SEMVER_SPEC_VERSION,
   RELEASE_TYPES: constants.RELEASE_TYPES,
   compareIdentifiers: identifiers.compareIdentifiers,

--- a/internal/constants.js
+++ b/internal/constants.js
@@ -23,12 +23,18 @@ const RELEASE_TYPES = [
   'prerelease',
 ]
 
+// Note: this is the regex provided by semver.org
+// This regex is not used inside this code within parsing functions
+// For more information about this regex, please visit https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+const SEMVER_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+
 module.exports = {
   MAX_LENGTH,
   MAX_SAFE_COMPONENT_LENGTH,
   MAX_SAFE_BUILD_LENGTH,
   MAX_SAFE_INTEGER,
   RELEASE_TYPES,
+  SEMVER_REGEX,
   SEMVER_SPEC_VERSION,
   FLAG_INCLUDE_PRERELEASE: 0b001,
   FLAG_LOOSE: 0b010,


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This PR introduces a new constant `SEMVER_REGEX` and its value is the regex provided by Semver.org.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
