### PR TITLE
fix: typo in compareBuild debug message

### DIFF
--- a/classes/semver.js
+++ b/classes/semver.js
@@ -158,7 +158,7 @@ class SemVer {
     do {
       const a = this.build[i]
       const b = other.build[i]
-      debug('prerelease compare', i, a, b)
+      debug('build compare', i, a, b)
       if (a === undefined && b === undefined) {
         return 0
       } else if (b === undefined) {


### PR DESCRIPTION
Correcting the debug message in `compareBuild` 