### PR TITLE
Update semver.js to include this.build inside of format()

### DIFF
--- a/classes/semver.js
+++ b/classes/semver.js
@@ -81,6 +81,9 @@ class SemVer {
     if (this.prerelease.length) {
       this.version += `-${this.prerelease.join('.')}`
     }
+    if (this.build.length) {
+      this.version += `+${this.build.join('.')}`
+    }
     return this.version
   }
 

--- a/test/classes/semver.js
+++ b/test/classes/semver.js
@@ -139,3 +139,20 @@ test('compareBuild', (t) => {
 
   t.end()
 })
+
+test('format method produces correct version string', t => {
+  const formatTestCases = [
+    {version: '1.2.3', options: {}, expected: '1.2.3'},
+    {version: '1.2.3-alpha.1', options: {}, expected: '1.2.3-alpha.1'},
+    {version: '1.2.3+build.11', options: {}, expected: '1.2.3+build.11'},
+    {version: '1.2.3-alpha.1+build.11', options: {}, expected: '1.2.3-alpha.1+build.11'},
+  ];
+
+  t.plan(formatTestCases.length);
+
+  formatTestCases.forEach(({ version, options, expected }) => {
+    const semVer = new SemVer(version, options);
+    t.equal(semVer.format(), expected, `Format of ${version} should be ${expected}`);
+  });
+});
+


### PR DESCRIPTION


<!-- What / Why -->
when you preformed format(), it was missing the this.build to be referenced. so if anyone was using this.build and setting it manually. It would not go through. This is seriously a issue, and caused abuncha issues until I realized what was wrong.

<!-- Describe the request in detail. What it does and why it's being changed. -->

just adding this.build to the format() function
