### PR TITLE
chore!: bump lru-cache to 10.x & increase node engine

### DIFF
--- a/classes/range.js
+++ b/classes/range.js
@@ -199,7 +199,7 @@ class Range {
 module.exports = Range
 
 const LRU = require('lru-cache')
-const cache = new LRU({ max: 1000 })
+const cache = new LRU.LRUCache({ max: 1000 })
 
 const parseOptions = require('../internal/parse-options')
 const Comparator = require('./comparator')

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     ]
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=16"
   },
   "dependencies": {
-    "lru-cache": "^6.0.0"
+    "lru-cache": "^10.2.0"
   },
   "author": "GitHub Inc.",
   "templateOSS": {


### PR DESCRIPTION
Trying to improve/solve the issue with dedupe on `cli`: https://github.com/npm/cli/issues/7350

I don't know if it's a good idea since `semver` is being used by a lot of projects and bumping the version of `node-lru-cache` requires the bump of `engines.node` to `>=16` , dropping a lot of node versions at once.

