### PR TITLE
deps: remove lru-cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,6 @@
   "engines": {
     "node": ">=10"
   },
-  "dependencies": {
-    "lru-cache": "^6.0.0"
-  },
   "author": "GitHub Inc.",
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",


### PR DESCRIPTION
The `lru-cache` package is out-of-date (6.0.0) but would require a major to bring to latest due to node engine requirements. 

This removes the dependency on the `lru-cache` package. It's replaced by a class in this package (#697).

## References

https://github.com/npm/node-semver/pull/695
https://github.com/npm/cli/issues/7350
