### PR TITLE
replace lru-cache dependency

### DIFF
--- a/bin/semver.js
+++ b/bin/semver.js
@@ -119,7 +119,11 @@ const main = () => {
       return fail()
     }
   }
-  return success(versions)
+  versions
+    .sort((a, b) => semver[reverse ? 'rcompare' : 'compare'](a, b, options))
+    .map(v => semver.clean(v, options))
+    .map(v => inc ? semver.inc(v, inc, options, identifier, identifierBase) : v)
+    .forEach(v => console.log(v))
 }
 
 const failInc = () => {
@@ -128,19 +132,6 @@ const failInc = () => {
 }
 
 const fail = () => process.exit(1)
-
-const success = () => {
-  const compare = reverse ? 'rcompare' : 'compare'
-  versions.sort((a, b) => {
-    return semver[compare](a, b, options)
-  }).map((v) => {
-    return semver.clean(v, options)
-  }).map((v) => {
-    return inc ? semver.inc(v, inc, options, identifier, identifierBase) : v
-  }).forEach((v, i, _) => {
-    console.log(v)
-  })
-}
 
 const help = () => console.log(
 `SemVer ${version}

--- a/classes/range.js
+++ b/classes/range.js
@@ -470,9 +470,10 @@ const replaceGTE0 = (comp, options) => {
 // 1.2 - 3.4.5 => >=1.2.0 <=3.4.5
 // 1.2.3 - 3.4 => >=1.2.0 <3.5.0-0 Any 3.4.x will do
 // 1.2 - 3.4 => >=1.2.0 <3.5.0-0
+// TODO build?
 const hyphenReplace = incPr => ($0,
   from, fM, fm, fp, fpr, fb,
-  to, tM, tm, tp, tpr, tb) => {
+  to, tM, tm, tp, tpr) => {
   if (isX(fM)) {
     from = ''
   } else if (isX(fm)) {

--- a/classes/range.js
+++ b/classes/range.js
@@ -198,8 +198,8 @@ class Range {
 
 module.exports = Range
 
-const LRU = require('lru-cache')
-const cache = new LRU({ max: 1000 })
+const LRU = require('../internal/lrucache')
+const cache = new LRU()
 
 const parseOptions = require('../internal/parse-options')
 const Comparator = require('./comparator')

--- a/internal/lrucache.js
+++ b/internal/lrucache.js
@@ -1,0 +1,45 @@
+class LRUCache {
+  constructor () {
+    this.max = 1000
+    this.map = new Map()
+  }
+
+  get (key) {
+    const value = this.map.get(key)
+    if (value === undefined) {
+      return undefined
+    } else {
+      // Remove the key from the map and add it to the end
+      this.map.delete(key)
+      this.map.set(key, value)
+      return value
+    }
+  }
+
+  delete (key) {
+    if (this.map.has(key)) {
+      this.map.delete(key)
+      return true
+    } else {
+      return false
+    }
+  }
+
+  set (key, value) {
+    const deleted = this.delete(key)
+
+    if (!deleted && value !== undefined) {
+      // If cache is full, delete the least recently used item
+      if (this.map.size >= this.max) {
+        const firstKey = this.map.keys().next().value
+        this.delete(firstKey)
+      }
+
+      this.map.set(key, value)
+    }
+
+    return this
+  }
+}
+
+module.exports = LRUCache

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
   "engines": {
     "node": ">=10"
   },
+  "dependencies": {
+    "lru-cache": "^6.0.0"
+  },
   "author": "GitHub Inc.",
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,6 @@
   "engines": {
     "node": ">=10"
   },
-  "dependencies": {
-    "lru-cache": "^6.0.0"
-  },
   "author": "GitHub Inc.",
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",

--- a/test/classes/range.js
+++ b/test/classes/range.js
@@ -105,3 +105,13 @@ test('missing range parameter in range intersect', (t) => {
   'throws type error')
   t.end()
 })
+
+test('cache', (t) => {
+  const cached = Symbol('cached')
+  const r1 = new Range('1.0.0')
+  r1.set[0][cached] = true
+  const r2 = new Range('1.0.0')
+  t.equal(r1.set[0][cached], true)
+  t.equal(r2.set[0][cached], true) // Will be true, showing it's cached.
+  t.end()
+})

--- a/test/internal/lrucache.js
+++ b/test/internal/lrucache.js
@@ -1,0 +1,19 @@
+const { test } = require('tap')
+const LRUCache = require('../../internal/lrucache')
+
+test('basic cache operation', t => {
+  const c = new LRUCache()
+  const max = 1000
+
+  for (let i = 0; i < max; i++) {
+    t.equal(c.set(i, i), c)
+  }
+  for (let i = 0; i < max; i++) {
+    t.equal(c.get(i), i)
+  }
+  c.set(1001, 1001)
+  // lru item should be gone
+  t.equal(c.get(0), undefined)
+  c.set(42, undefined)
+  t.end()
+})


### PR DESCRIPTION
This is a rebase of https://github.com/npm/node-semver/pull/697 to
isolate the changes into two discrete commits.

- **deps: remove lru-cache**
- **fix: use internal cache implementation**
