### PR TITLE
deps: uninstall `lru-cache`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,6 @@
   "engines": {
     "node": ">=10"
   },
-  "dependencies": {
-    "lru-cache": "^6.0.0"
-  },
   "author": "GitHub Inc.",
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
#704 removed usage of `lru-cache`, but the dependency wasn't removed from `package.json`

## References
Related to #704
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
