### PR TITLE
fix(lru): use map.delete() directly

### DIFF
--- a/internal/lrucache.js
+++ b/internal/lrucache.js
@@ -17,7 +17,7 @@ class LRUCache {
   }
 
   delete (key) {
-    return this.map.delete(key);
+    return this.map.delete(key)
   }
 
   set (key, value) {

--- a/internal/lrucache.js
+++ b/internal/lrucache.js
@@ -17,12 +17,7 @@ class LRUCache {
   }
 
   delete (key) {
-    if (this.map.has(key)) {
-      this.map.delete(key)
-      return true
-    } else {
-      return false
-    }
+    return this.map.delete(key);
   }
 
   set (key, value) {


### PR DESCRIPTION
The default implementation already returns boolean if the value has been deleted.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete#return_value

It's also faster since we don't double check the hashmap for a value.