### PR TITLE
fix(lru): don't clear an already cached key on set

### DIFF
--- a/internal/lrucache.js
+++ b/internal/lrucache.js
@@ -21,9 +21,9 @@ class LRUCache {
   }
 
   set (key, value) {
-    const deleted = this.delete(key)
+    this.delete(key)
 
-    if (!deleted && value !== undefined) {
+    if (value !== undefined) {
       // If cache is full, delete the least recently used item
       if (this.map.size >= this.max) {
         const firstKey = this.map.keys().next().value

--- a/test/internal/lrucache.js
+++ b/test/internal/lrucache.js
@@ -17,3 +17,25 @@ test('basic cache operation', t => {
   c.set(42, undefined)
   t.end()
 })
+
+test('test setting the same key twice', t => {
+  const c = new LRUCache()
+  c.set(1, 1)
+  c.set(1, 2)
+  t.equal(c.get(1), 2)
+  t.end()
+})
+
+test('test that setting an already cached key bumps it last in the LRU queue', t => {
+  const c = new LRUCache()
+  const max = 1000
+
+  for (let i = 0; i < max; i++) {
+    c.set(i, i)
+  }
+  c.set(0, 0)
+  c.set(1001, 1001)
+  t.equal(c.get(0), 0)
+  t.equal(c.get(1), undefined)
+  t.end()
+})


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This pull request modifies how the LRU cache implementation handles setting a key that's already in the cache. Previously, if an already cached key was set again, then it was always cleared from the cache:

```js
> const cache = new LRUCache();
> cache.set(1, 1);
> cache.set(1, 2);
> cache.get(1);
undefined
```

This pull request's modified version returns `2` for `cache.get(1)`. The newly set key is still bumped to the last place in the LRU queue. There are two new tests to check this behavior.

The current semver implementation might never trigger this behavior, in which case this pull request is just future-proofing.