### PR TITLE
docs: clarify comment about obsolete prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ A "version" is described by the `v2.0.0` specification found at
 <https://semver.org/>.
 
 A leading `"="` or `"v"` character is stripped off and ignored.
-These prefixes are kept for compatibility with `v1.0.0` of the SemVer
+A leading "v" is kept for compatibility with `v1.0.0` of the SemVer
 specification but should not be used anymore.
 
 ## Ranges

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ A "version" is described by the `v2.0.0` specification found at
 <https://semver.org/>.
 
 A leading `"="` or `"v"` character is stripped off and ignored.
+These prefixes are kept for compatibility with `v1.0.0` of the SemVer
+specification but should not be used anymore.
 
 ## Ranges
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ A "version" is described by the `v2.0.0` specification found at
 <https://semver.org/>.
 
 A leading `"="` or `"v"` character is stripped off and ignored.
-A leading "v" is kept for compatibility with `v1.0.0` of the SemVer
+Support for stripping a leading "v" is kept for compatibility with `v1.0.0` of the SemVer
 specification but should not be used anymore.
 
 ## Ranges


### PR DESCRIPTION
Adds an explanation why the "=" and "v" prefixes should not be used anymore.