### PR TITLE
fix pre* increments, add release increment

### DIFF
--- a/classes/semver.js
+++ b/classes/semver.js
@@ -177,6 +177,12 @@ class SemVer {
   inc (release, identifier, identifierBase) {
     const inferredIdentifier = identifier || this.prerelease[0] || undefined
     switch (release) {
+      case 'release':
+        if (this.prerelease.length === 0) {
+          throw new Error(`version ${this.raw} is not a prerelease`)
+        }
+        this.prerelease.length = 0
+        break
       case 'premajor':
         if (this.minor || this.patch || this.prerelease.length === 0) {
           this.prerelease.length = 0


### PR DESCRIPTION
This PR has two changes:

- **fix: don't leapfrog versions during premajor et al**
- **feat: add "release" inc type**

The bug is outlined in https://github.com/npm/node-semver/issues/751
The feature is defined in https://github.com/npm/node-semver/issues/740

This is a draft while we discuss #751.
This will need docs and tests of course.
