### PR TITLE
docs(readme): added missing period for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ strings that they parse.
 
 ### Ranges
 
-* `validRange(range)`: Return the valid range or null if it's not valid
+* `validRange(range)`: Return the valid range or null if it's not valid.
 * `satisfies(version, range)`: Return true if the version satisfies the
   range.
 * `maxSatisfying(versions, range)`: Return the highest version in the list


### PR DESCRIPTION
Added a missing period in specific parts of the text to maintain consistency across the document. This ensures a uniform writing style, improves readability, and aligns with the formatting used throughout the content.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
