### PR TITLE
chore(package): explicitly declare js module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.7.1",
   "description": "The semantic version parser used by npm.",
   "main": "index.js",
+  "type": "commonjs",
   "scripts": {
     "test": "tap",
     "snap": "tap",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

[Node 21.1.0 added a flag to detect module types](https://github.com/nodejs/node/releases/tag/v21.1.0) that became enabled by [default in Node 22.7.0](https://nodejs.org/api/packages.html#syntax-detection).
Declaring the type will cause Node to skip detection on startup, reducing startup time.

Declaring the package type is also considered good practice according to https://nodejs.org/api/modules.html#enabling.