### PR TITLE
fix: add missing `'use strict'` directives

### DIFF
--- a/.eslintrc.local.js
+++ b/.eslintrc.local.js
@@ -12,6 +12,7 @@ module.exports = {
           },
         ],
         'import/no-nodejs-modules': ['error'],
+        strict: ['error', 'global'],
       },
     },
   ],

--- a/benchmarks/bench-compare.js
+++ b/benchmarks/bench-compare.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Benchmark = require('benchmark')
 const SemVer = require('../classes/semver')
 const suite = new Benchmark.Suite()

--- a/benchmarks/bench-diff.js
+++ b/benchmarks/bench-diff.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Benchmark = require('benchmark')
 const diff = require('../functions/diff')
 const suite = new Benchmark.Suite()

--- a/benchmarks/bench-parse-options.js
+++ b/benchmarks/bench-parse-options.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Benchmark = require('benchmark')
 const parseOptions = require('../internal/parse-options')
 const suite = new Benchmark.Suite()

--- a/benchmarks/bench-parse.js
+++ b/benchmarks/bench-parse.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Benchmark = require('benchmark')
 const parse = require('../functions/parse')
 const { MAX_SAFE_INTEGER } = require('../internal/constants')

--- a/benchmarks/bench-satisfies.js
+++ b/benchmarks/bench-satisfies.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Benchmark = require('benchmark')
 const satisfies = require('../functions/satisfies')
 const suite = new Benchmark.Suite()

--- a/benchmarks/bench-subset.js
+++ b/benchmarks/bench-subset.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Benchmark = require('benchmark')
 const subset = require('../ranges/subset')
 const suite = new Benchmark.Suite()

--- a/bin/semver.js
+++ b/bin/semver.js
@@ -3,6 +3,8 @@
 // Exits successfully and prints matching version(s) if
 // any supplied version is valid and passes all tests.
 
+'use strict'
+
 const argv = process.argv.slice(2)
 
 let versions = []

--- a/classes/comparator.js
+++ b/classes/comparator.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const ANY = Symbol('SemVer ANY')
 // hoisted class for cyclic dependency
 class Comparator {

--- a/classes/index.js
+++ b/classes/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = {
   SemVer: require('./semver.js'),
   Range: require('./range.js'),

--- a/classes/range.js
+++ b/classes/range.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SPACE_CHARACTERS = /\s+/g
 
 // hoisted class for cyclic dependency

--- a/classes/semver.js
+++ b/classes/semver.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const debug = require('../internal/debug')
 const { MAX_LENGTH, MAX_SAFE_INTEGER } = require('../internal/constants')
 const { safeRe: re, safeSrc: src, t } = require('../internal/re')

--- a/functions/clean.js
+++ b/functions/clean.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const parse = require('./parse')
 const clean = (version, options) => {
   const s = parse(version.trim().replace(/^[=v]+/, ''), options)

--- a/functions/cmp.js
+++ b/functions/cmp.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const eq = require('./eq')
 const neq = require('./neq')
 const gt = require('./gt')

--- a/functions/coerce.js
+++ b/functions/coerce.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const parse = require('./parse')
 const { safeRe: re, t } = require('../internal/re')

--- a/functions/compare-build.js
+++ b/functions/compare-build.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const compareBuild = (a, b, loose) => {
   const versionA = new SemVer(a, loose)

--- a/functions/compare-loose.js
+++ b/functions/compare-loose.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const compare = require('./compare')
 const compareLoose = (a, b) => compare(a, b, true)
 module.exports = compareLoose

--- a/functions/compare.js
+++ b/functions/compare.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const compare = (a, b, loose) =>
   new SemVer(a, loose).compare(new SemVer(b, loose))

--- a/functions/diff.js
+++ b/functions/diff.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const parse = require('./parse.js')
 
 const diff = (version1, version2) => {

--- a/functions/eq.js
+++ b/functions/eq.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const compare = require('./compare')
 const eq = (a, b, loose) => compare(a, b, loose) === 0
 module.exports = eq

--- a/functions/gt.js
+++ b/functions/gt.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const compare = require('./compare')
 const gt = (a, b, loose) => compare(a, b, loose) > 0
 module.exports = gt

--- a/functions/gte.js
+++ b/functions/gte.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const compare = require('./compare')
 const gte = (a, b, loose) => compare(a, b, loose) >= 0
 module.exports = gte

--- a/functions/inc.js
+++ b/functions/inc.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 
 const inc = (version, release, options, identifier, identifierBase) => {

--- a/functions/lt.js
+++ b/functions/lt.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const compare = require('./compare')
 const lt = (a, b, loose) => compare(a, b, loose) < 0
 module.exports = lt

--- a/functions/lte.js
+++ b/functions/lte.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const compare = require('./compare')
 const lte = (a, b, loose) => compare(a, b, loose) <= 0
 module.exports = lte

--- a/functions/major.js
+++ b/functions/major.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const major = (a, loose) => new SemVer(a, loose).major
 module.exports = major

--- a/functions/minor.js
+++ b/functions/minor.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const minor = (a, loose) => new SemVer(a, loose).minor
 module.exports = minor

--- a/functions/neq.js
+++ b/functions/neq.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const compare = require('./compare')
 const neq = (a, b, loose) => compare(a, b, loose) !== 0
 module.exports = neq

--- a/functions/parse.js
+++ b/functions/parse.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const parse = (version, options, throwErrors = false) => {
   if (version instanceof SemVer) {

--- a/functions/patch.js
+++ b/functions/patch.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const patch = (a, loose) => new SemVer(a, loose).patch
 module.exports = patch

--- a/functions/prerelease.js
+++ b/functions/prerelease.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const parse = require('./parse')
 const prerelease = (version, options) => {
   const parsed = parse(version, options)

--- a/functions/rcompare.js
+++ b/functions/rcompare.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const compare = require('./compare')
 const rcompare = (a, b, loose) => compare(b, a, loose)
 module.exports = rcompare

--- a/functions/rsort.js
+++ b/functions/rsort.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const compareBuild = require('./compare-build')
 const rsort = (list, loose) => list.sort((a, b) => compareBuild(b, a, loose))
 module.exports = rsort

--- a/functions/satisfies.js
+++ b/functions/satisfies.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Range = require('../classes/range')
 const satisfies = (version, range, options) => {
   try {

--- a/functions/sort.js
+++ b/functions/sort.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const compareBuild = require('./compare-build')
 const sort = (list, loose) => list.sort((a, b) => compareBuild(a, b, loose))
 module.exports = sort

--- a/functions/valid.js
+++ b/functions/valid.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const parse = require('./parse')
 const valid = (version, options) => {
   const v = parse(version, options)

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // just pre-load all the stuff that index.js lazily exports
 const internalRe = require('./internal/re')
 const constants = require('./internal/constants')

--- a/internal/constants.js
+++ b/internal/constants.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // Note: this is the semver.org version of the spec that it implements
 // Not necessarily the package version of this code.
 const SEMVER_SPEC_VERSION = '2.0.0'

--- a/internal/debug.js
+++ b/internal/debug.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const debug = (
   typeof process === 'object' &&
   process.env &&

--- a/internal/identifiers.js
+++ b/internal/identifiers.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const numeric = /^[0-9]+$/
 const compareIdentifiers = (a, b) => {
   const anum = numeric.test(a)

--- a/internal/lrucache.js
+++ b/internal/lrucache.js
@@ -1,3 +1,5 @@
+'use strict'
+
 class LRUCache {
   constructor () {
     this.max = 1000

--- a/internal/parse-options.js
+++ b/internal/parse-options.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // parse out just the options we care about
 const looseOption = Object.freeze({ loose: true })
 const emptyOpts = Object.freeze({ })

--- a/internal/re.js
+++ b/internal/re.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const {
   MAX_SAFE_COMPONENT_LENGTH,
   MAX_SAFE_BUILD_LENGTH,

--- a/map.js
+++ b/map.js
@@ -1,1 +1,3 @@
+'use strict'
+
 module.exports = testFile => testFile.replace(/test\//, '')

--- a/preload.js
+++ b/preload.js
@@ -1,2 +1,4 @@
+'use strict'
+
 // XXX remove in v8 or beyond
 module.exports = require('./index.js')

--- a/ranges/gtr.js
+++ b/ranges/gtr.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // Determine if version is greater than all the versions possible in the range.
 const outside = require('./outside')
 const gtr = (version, range, options) => outside(version, range, '>', options)

--- a/ranges/intersects.js
+++ b/ranges/intersects.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Range = require('../classes/range')
 const intersects = (r1, r2, options) => {
   r1 = new Range(r1, options)

--- a/ranges/ltr.js
+++ b/ranges/ltr.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const outside = require('./outside')
 // Determine if version is less than all the versions possible in the range
 const ltr = (version, range, options) => outside(version, range, '<', options)

--- a/ranges/max-satisfying.js
+++ b/ranges/max-satisfying.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const Range = require('../classes/range')
 

--- a/ranges/min-satisfying.js
+++ b/ranges/min-satisfying.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const Range = require('../classes/range')
 const minSatisfying = (versions, range, options) => {

--- a/ranges/min-version.js
+++ b/ranges/min-version.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const Range = require('../classes/range')
 const gt = require('../functions/gt')

--- a/ranges/outside.js
+++ b/ranges/outside.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const SemVer = require('../classes/semver')
 const Comparator = require('../classes/comparator')
 const { ANY } = Comparator

--- a/ranges/simplify.js
+++ b/ranges/simplify.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // given a set of versions and a range, create a "simplified" range
 // that includes the same versions that the original range does
 // If the original range is shorter than the simplified one, return that.

--- a/ranges/subset.js
+++ b/ranges/subset.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Range = require('../classes/range.js')
 const Comparator = require('../classes/comparator.js')
 const { ANY } = Comparator

--- a/ranges/to-comparators.js
+++ b/ranges/to-comparators.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Range = require('../classes/range')
 
 // Mostly just for testing and legacy API reasons

--- a/ranges/valid.js
+++ b/ranges/valid.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Range = require('../classes/range')
 const validRange = (range, options) => {
   try {

--- a/test/bin/semver.js
+++ b/test/bin/semver.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const t = require('tap')
 
 const thisVersion = require('../../package.json').version

--- a/test/classes/comparator.js
+++ b/test/classes/comparator.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const Comparator = require('../../classes/comparator')
 const comparatorIntersection = require('../fixtures/comparator-intersection.js')

--- a/test/classes/index.js
+++ b/test/classes/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 t.same(require('../../classes'), {
   SemVer: require('../../classes/semver'),

--- a/test/classes/range.js
+++ b/test/classes/range.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const Range = require('../../classes/range')
 const Comparator = require('../../classes/comparator')

--- a/test/classes/semver.js
+++ b/test/classes/semver.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const SemVer = require('../../classes/semver')
 const increments = require('../fixtures/increments.js')

--- a/test/fixtures/comparator-intersection.js
+++ b/test/fixtures/comparator-intersection.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // c0, c1, expected intersection, includePrerelease
 module.exports = [
   // One is a Version

--- a/test/fixtures/comparisons.js
+++ b/test/fixtures/comparisons.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // [version1, version2]
 // version1 should be greater than version2
 // used by the cmp, eq, gt, lt, and neq tests

--- a/test/fixtures/equality.js
+++ b/test/fixtures/equality.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // [version1, version2]
 // version1 should be equivalent to version2
 module.exports = [

--- a/test/fixtures/increments.js
+++ b/test/fixtures/increments.js
@@ -1,3 +1,5 @@
+'use strict'
+
 //  [version, inc, result, options, identifier, identifierBase]
 //  inc(version, inc, options, identifier, identifierBase) -> result
 module.exports = [

--- a/test/fixtures/invalid-versions.js
+++ b/test/fixtures/invalid-versions.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // none of these are semvers
 // [value, reason, opt]
 const { MAX_LENGTH, MAX_SAFE_INTEGER } = require('../../internal/constants')

--- a/test/fixtures/range-exclude.js
+++ b/test/fixtures/range-exclude.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // [range, version, options]
 // version should not be included by range
 module.exports = [

--- a/test/fixtures/range-include.js
+++ b/test/fixtures/range-include.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // [range, version, options]
 // version should be included by range
 module.exports = [

--- a/test/fixtures/range-intersection.js
+++ b/test/fixtures/range-intersection.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // r0, r1, expected intersection
 module.exports = [
   ['1.3.0 || <1.0.0 >2.0.0', '1.3.0 || <1.0.0 >2.0.0', true],

--- a/test/fixtures/range-parse.js
+++ b/test/fixtures/range-parse.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // [range, canonical result, options]
 // null result means it's not a valid range
 // '*' is the return value from functions.validRange(), but

--- a/test/fixtures/version-gt-range.js
+++ b/test/fixtures/version-gt-range.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // [range, version, options]
 // Version should be greater than range
 module.exports = [

--- a/test/fixtures/version-lt-range.js
+++ b/test/fixtures/version-lt-range.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // [range, version, options]
 // Version should be less than range
 module.exports = [

--- a/test/fixtures/version-not-gt-range.js
+++ b/test/fixtures/version-not-gt-range.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // [range, version, options]
 // Version should NOT be greater than range
 module.exports = [

--- a/test/fixtures/version-not-lt-range.js
+++ b/test/fixtures/version-not-lt-range.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // [range, version, options]
 // Version should NOT be less than range
 module.exports = [

--- a/test/functions/clean.js
+++ b/test/functions/clean.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const clean = require('../../functions/clean')
 

--- a/test/functions/cmp.js
+++ b/test/functions/cmp.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const cmp = require('../../functions/cmp')
 const comparisons = require('../fixtures/comparisons.js')

--- a/test/functions/coerce.js
+++ b/test/functions/coerce.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const coerce = require('../../functions/coerce')
 const parse = require('../../functions/parse')

--- a/test/functions/compare-build.js
+++ b/test/functions/compare-build.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const compareBuild = require('../../functions/compare-build')
 

--- a/test/functions/compare-loose.js
+++ b/test/functions/compare-loose.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const compareLoose = require('../../functions/compare-loose')
 const SemVer = require('../../classes/semver')

--- a/test/functions/compare.js
+++ b/test/functions/compare.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const compare = require('../../functions/compare.js')
 const comparisons = require('../fixtures/comparisons.js')

--- a/test/functions/diff.js
+++ b/test/functions/diff.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const diff = require('../../functions/diff')
 

--- a/test/functions/eq.js
+++ b/test/functions/eq.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const eq = require('../../functions/eq')
 const comparisons = require('../fixtures/comparisons.js')

--- a/test/functions/gt.js
+++ b/test/functions/gt.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const gt = require('../../functions/gt')
 const comparisons = require('../fixtures/comparisons.js')

--- a/test/functions/gte.js
+++ b/test/functions/gte.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const gte = require('../../functions/gte')
 const comparisons = require('../fixtures/comparisons.js')

--- a/test/functions/inc.js
+++ b/test/functions/inc.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const inc = require('../../functions/inc')
 const parse = require('../../functions/parse')

--- a/test/functions/lt.js
+++ b/test/functions/lt.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const lt = require('../../functions/lt')
 const comparisons = require('../fixtures/comparisons.js')

--- a/test/functions/lte.js
+++ b/test/functions/lte.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const lte = require('../../functions/lte')
 const comparisons = require('../fixtures/comparisons.js')

--- a/test/functions/major.js
+++ b/test/functions/major.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const major = require('../../functions/major')
 

--- a/test/functions/minor.js
+++ b/test/functions/minor.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const minor = require('../../functions/minor')
 

--- a/test/functions/neq.js
+++ b/test/functions/neq.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const neq = require('../../functions/neq')
 const comparisons = require('../fixtures/comparisons.js')

--- a/test/functions/parse.js
+++ b/test/functions/parse.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 const parse = require('../../functions/parse')
 const SemVer = require('../../classes/semver')

--- a/test/functions/patch.js
+++ b/test/functions/patch.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const patch = require('../../functions/patch')
 

--- a/test/functions/prerelease.js
+++ b/test/functions/prerelease.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const prerelease = require('../../functions/prerelease')
 

--- a/test/functions/rcompare.js
+++ b/test/functions/rcompare.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const rcompare = require('../../functions/rcompare')
 

--- a/test/functions/rsort.js
+++ b/test/functions/rsort.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const rsort = require('../../functions/rsort')
 

--- a/test/functions/satisfies.js
+++ b/test/functions/satisfies.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const satisfies = require('../../functions/satisfies')
 const rangeInclude = require('../fixtures/range-include.js')

--- a/test/functions/sort.js
+++ b/test/functions/sort.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const sort = require('../../functions/sort')
 

--- a/test/functions/valid.js
+++ b/test/functions/valid.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 const valid = require('../../functions/valid')
 const SemVer = require('../../classes/semver')

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 const semver = require('../')
 const { SEMVER_SPEC_VERSION } = require('../internal/constants')

--- a/test/integration/whitespace.js
+++ b/test/integration/whitespace.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const Range = require('../../classes/range')
 const SemVer = require('../../classes/semver')

--- a/test/internal/constants.js
+++ b/test/internal/constants.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 const constants = require('../../internal/constants')
 

--- a/test/internal/debug.js
+++ b/test/internal/debug.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const main = () => {
   const t = require('tap')
   const { spawn } = require('child_process')

--- a/test/internal/identifiers.js
+++ b/test/internal/identifiers.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const { compareIdentifiers, rcompareIdentifiers } = require('../../internal/identifiers')
 

--- a/test/internal/lrucache.js
+++ b/test/internal/lrucache.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const LRUCache = require('../../internal/lrucache')
 

--- a/test/internal/parse-options.js
+++ b/test/internal/parse-options.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 const parseOptions = require('../../internal/parse-options.js')
 

--- a/test/internal/re.js
+++ b/test/internal/re.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const { src, re, safeRe, safeSrc } = require('../../internal/re')
 const semver = require('../../')

--- a/test/map.js
+++ b/test/map.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 const { resolve, join, relative, extname, dirname, basename } = require('path')
 const { statSync, readdirSync } = require('fs')

--- a/test/preload.js
+++ b/test/preload.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 const preload = require('../preload.js')
 const index = require('../index.js')

--- a/test/ranges/gtr.js
+++ b/test/ranges/gtr.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const gtr = require('../../ranges/gtr')
 const versionGtr = require('../fixtures/version-gt-range')

--- a/test/ranges/intersects.js
+++ b/test/ranges/intersects.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const intersects = require('../../ranges/intersects')
 const Range = require('../../classes/range')

--- a/test/ranges/ltr.js
+++ b/test/ranges/ltr.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const ltr = require('../../ranges/ltr')
 const versionLtr = require('../fixtures/version-lt-range')

--- a/test/ranges/max-satisfying.js
+++ b/test/ranges/max-satisfying.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const maxSatisfying = require('../../ranges/max-satisfying')
 

--- a/test/ranges/min-satisfying.js
+++ b/test/ranges/min-satisfying.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const minSatisfying = require('../../ranges/min-satisfying')
 

--- a/test/ranges/min-version.js
+++ b/test/ranges/min-version.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const minVersion = require('../../ranges/min-version')
 

--- a/test/ranges/outside.js
+++ b/test/ranges/outside.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const outside = require('../../ranges/outside')
 const versionGtr = require('../fixtures/version-gt-range')

--- a/test/ranges/simplify.js
+++ b/test/ranges/simplify.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const simplify = require('../../ranges/simplify.js')
 const Range = require('../../classes/range.js')
 const t = require('tap')

--- a/test/ranges/subset.js
+++ b/test/ranges/subset.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 const subset = require('../../ranges/subset.js')
 const Range = require('../../classes/range')

--- a/test/ranges/to-comparators.js
+++ b/test/ranges/to-comparators.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const toComparators = require('../../ranges/to-comparators')
 

--- a/test/ranges/valid.js
+++ b/test/ranges/valid.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const validRange = require('../../ranges/valid')
 const rangeParse = require('../fixtures/range-parse.js')


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Adds missing `'use strict'` directives;  this directive is dotted around a handful of files in the repo so this PR adds it to the rest of the CJS files.


The local eslint file has been updated to enforce this going forward, as suggested in the linked issue.

## References
Closes #774 
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
