### PR TITLE
feat: allow strict semver check

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ semver.lt('1.2.3', '9.8.7') // true
 semver.minVersion('>=1.0.0') // '1.0.0'
 semver.valid(semver.coerce('v2')) // '2.0.0'
 semver.valid(semver.coerce('42.6.7.9.3-alpha')) // '42.6.7'
+
+// Strict mode - rejects version strings with 'v' prefix
+semver.valid('v1.2.3') // '1.2.3' (default behavior)
+semver.valid('v1.2.3', { strict: true }) // throws TypeError
+semver.valid('1.2.3', { strict: true }) // '1.2.3'
 ```
 
 You can also just load the module for the function that you care about if
@@ -419,6 +424,10 @@ are:
   behavior](https://github.com/npm/node-semver#prerelease-tags) of
   excluding prerelease tagged versions from ranges unless they are
   explicitly opted into.
+- `strict`: When set to `true`, versions with leading "v" or "V" prefixes
+  will be rejected and throw a TypeError. By default (when `false`), such
+  prefixes are allowed and stripped. This option enforces strict SemVer
+  compliance where version strings must not contain prefixes.
 
 Strict-mode Comparators and Ranges will be strict about the SemVer
 strings that they parse.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Options:
 -p --include-prerelease
         Always include prerelease versions in range matching
 
+-s --strict
+        Reject version strings with leading 'v' prefix
+        (throws error if version starts with 'v' or 'V')
+
 -c --coerce
         Coerce a string into SemVer if possible
         (does not imply --loose)

--- a/classes/semver.js
+++ b/classes/semver.js
@@ -34,6 +34,11 @@ class SemVer {
     // don't run into trouble passing this.options around.
     this.includePrerelease = !!options.includePrerelease
 
+    // Check for strict mode - reject versions with leading 'v'
+    if (options.strict && /^v/i.test(version.trim())) {
+      throw new TypeError(`Invalid version in strict mode: version cannot start with 'v'. Got: ${version}`)
+    }
+
     const m = version.trim().match(options.loose ? re[t.LOOSE] : re[t.FULL])
 
     if (!m) {

--- a/tap-snapshots/test/bin/semver.js.test.cjs
+++ b/tap-snapshots/test/bin/semver.js.test.cjs
@@ -83,6 +83,10 @@ Object {
     -p --include-prerelease
             Always include prerelease versions in range matching
     
+    -s --strict
+            Reject version strings with leading 'v' prefix
+            (throws error if version starts with 'v' or 'V')
+    
     -c --coerce
             Coerce a string into SemVer if possible
             (does not imply --loose)
@@ -143,6 +147,10 @@ Object {
     
     -p --include-prerelease
             Always include prerelease versions in range matching
+    
+    -s --strict
+            Reject version strings with leading 'v' prefix
+            (throws error if version starts with 'v' or 'V')
     
     -c --coerce
             Coerce a string into SemVer if possible
@@ -205,6 +213,10 @@ Object {
     -p --include-prerelease
             Always include prerelease versions in range matching
     
+    -s --strict
+            Reject version strings with leading 'v' prefix
+            (throws error if version starts with 'v' or 'V')
+    
     -c --coerce
             Coerce a string into SemVer if possible
             (does not imply --loose)
@@ -265,6 +277,10 @@ Object {
     
     -p --include-prerelease
             Always include prerelease versions in range matching
+    
+    -s --strict
+            Reject version strings with leading 'v' prefix
+            (throws error if version starts with 'v' or 'V')
     
     -c --coerce
             Coerce a string into SemVer if possible
@@ -344,15 +360,6 @@ Object {
   "code": 0,
   "err": "",
   "out": "2.0.0-beta.0\\n",
-  "signal": null,
-}
-`
-
-exports[`test/bin/semver.js TAP inc tests > -i release 1.0.0-pre`] = `
-Object {
-  "code": 0,
-  "err": "",
-  "out": "1.0.0\\n",
   "signal": null,
 }
 `
@@ -481,6 +488,60 @@ Object {
     2.3.4
     
   ),
+  "signal": null,
+}
+`
+
+exports[`test/bin/semver.js TAP strict mode tests > 1.2.3 --strict 1`] = `
+Object {
+  "code": 0,
+  "err": "",
+  "out": "1.2.3\\n",
+  "signal": null,
+}
+`
+
+exports[`test/bin/semver.js TAP strict mode tests > 1.2.3-alpha.1 -s 1`] = `
+Object {
+  "code": 0,
+  "err": "",
+  "out": "1.2.3-alpha.1\\n",
+  "signal": null,
+}
+`
+
+exports[`test/bin/semver.js TAP strict mode tests > V1.2.3 -s 1`] = `
+Object {
+  "code": 1,
+  "err": "Error: Invalid version in strict mode: version cannot start with 'v'. Got: V1.2.3\\n",
+  "out": "",
+  "signal": null,
+}
+`
+
+exports[`test/bin/semver.js TAP strict mode tests > V1.2.3 1`] = `
+Object {
+  "code": 1,
+  "err": "",
+  "out": "",
+  "signal": null,
+}
+`
+
+exports[`test/bin/semver.js TAP strict mode tests > v1.2.3 --strict 1`] = `
+Object {
+  "code": 1,
+  "err": "Error: Invalid version in strict mode: version cannot start with 'v'. Got: v1.2.3\\n",
+  "out": "",
+  "signal": null,
+}
+`
+
+exports[`test/bin/semver.js TAP strict mode tests > v1.2.3 1`] = `
+Object {
+  "code": 0,
+  "err": "",
+  "out": "1.2.3\\n",
   "signal": null,
 }
 `

--- a/test/bin/semver.js
+++ b/test/bin/semver.js
@@ -81,3 +81,15 @@ t.test('args with equals', t => Promise.all([
   t.equal(res1.out.trim(), expected)
   t.strictSame(res1, res2, args.join(' '))
 })))
+
+t.test('strict mode tests', t => Promise.all([
+  // Default behavior - v-prefix allowed
+  ['v1.2.3'],
+  ['V1.2.3'],
+  // Strict mode rejects v-prefix
+  ['v1.2.3', '--strict'],
+  ['V1.2.3', '-s'],
+  // Strict mode allows normal versions
+  ['1.2.3', '--strict'],
+  ['1.2.3-alpha.1', '-s'],
+].map(args => t.resolveMatchSnapshot(run(args), args.join(' ')))))

--- a/test/classes/semver.js
+++ b/test/classes/semver.js
@@ -184,3 +184,96 @@ test('compareBuild', (t) => {
 
   t.end()
 })
+
+test('strict option behavior', (t) => {
+  // Default behavior - v-prefix allowed
+  t.test('default allows v-prefix', (t) => {
+    const v = new SemVer('v1.2.3')
+    t.equal(v.version, '1.2.3')
+    t.equal(v.major, 1)
+    t.equal(v.minor, 2)
+    t.equal(v.patch, 3)
+    t.end()
+  })
+
+  // Explicit strict: false - v-prefix allowed
+  t.test('strict: false allows v-prefix', (t) => {
+    const v = new SemVer('v1.2.3', { strict: false })
+    t.equal(v.version, '1.2.3')
+    t.equal(v.major, 1)
+    t.equal(v.minor, 2)
+    t.equal(v.patch, 3)
+    t.end()
+  })
+
+  // Strict: true without v-prefix - should work
+  t.test('strict: true allows valid version', (t) => {
+    const v = new SemVer('1.2.3', { strict: true })
+    t.equal(v.version, '1.2.3')
+    t.equal(v.major, 1)
+    t.equal(v.minor, 2)
+    t.equal(v.patch, 3)
+    t.end()
+  })
+
+  // Strict: true with prerelease - should work
+  t.test('strict: true allows valid prerelease version', (t) => {
+    const v = new SemVer('1.2.3-alpha.1', { strict: true })
+    t.equal(v.version, '1.2.3-alpha.1')
+    t.equal(v.major, 1)
+    t.equal(v.minor, 2)
+    t.equal(v.patch, 3)
+    t.strictSame(v.prerelease, ['alpha', 1])
+    t.end()
+  })
+
+  // Strict: true with lowercase v-prefix - should throw
+  t.test('strict: true rejects lowercase v-prefix', (t) => {
+    t.throws(
+      () => new SemVer('v1.2.3', { strict: true }),
+      {
+        name: 'TypeError',
+        message: "Invalid version in strict mode: version cannot start with 'v'. Got: v1.2.3",
+      }
+    )
+    t.end()
+  })
+
+  // Strict: true with uppercase V-prefix - should throw
+  t.test('strict: true rejects uppercase V-prefix', (t) => {
+    t.throws(
+      () => new SemVer('V1.2.3', { strict: true }),
+      {
+        name: 'TypeError',
+        message: "Invalid version in strict mode: version cannot start with 'v'. Got: V1.2.3",
+      }
+    )
+    t.end()
+  })
+
+  // Strict: true with v-prefix and prerelease - should throw
+  t.test('strict: true rejects v-prefix with prerelease', (t) => {
+    t.throws(
+      () => new SemVer('v1.2.3-alpha.1', { strict: true }),
+      {
+        name: 'TypeError',
+        message: "Invalid version in strict mode: version cannot start with 'v'. Got: v1.2.3-alpha.1",
+      }
+    )
+    t.end()
+  })
+
+  // Strict: true with whitespace and v-prefix - should throw
+  t.test('strict: true rejects v-prefix with whitespace', (t) => {
+    t.throws(
+      () => new SemVer('  v1.2.3  ', { strict: true }),
+      {
+        name: 'TypeError',
+        message: "Invalid version in strict mode: version cannot start with 'v'. Got:   v1.2.3  ",
+      }
+    )
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/internal/parse-options.js
+++ b/test/internal/parse-options.js
@@ -32,6 +32,8 @@ t.test('any object passed is returned', t => {
   t.strictSame(parseOptions({ loose: true }), { loose: true })
   t.strictSame(parseOptions({ rtl: true }), { rtl: true })
   t.strictSame(parseOptions({ includePrerelease: true }), { includePrerelease: true })
+  t.strictSame(parseOptions({ strict: true }), { strict: true })
+  t.strictSame(parseOptions({ strict: false }), { strict: false })
   t.strictSame(parseOptions({ loose: true, rtl: true }), { loose: true, rtl: true })
   t.strictSame(parseOptions({ loose: true, includePrerelease: true }), {
     loose: true,
@@ -40,6 +42,11 @@ t.test('any object passed is returned', t => {
   t.strictSame(parseOptions({ rtl: true, includePrerelease: true }), {
     rtl: true,
     includePrerelease: true,
+  })
+  t.strictSame(parseOptions({ loose: true, includePrerelease: true, strict: true }), {
+    loose: true,
+    includePrerelease: true,
+    strict: true,
   })
   t.end()
 })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The Current Implementation does not follow SemVer v2 as stated in the doc.
This allows following the spec by making leading v as invalid with an option named "strict".

I'm open to renaming it if needed.

## References
Related to https://github.com/npm/node-semver/issues/376
and https://github.com/npm/node-semver/issues/376
and PR: https://github.com/npm/node-semver/pull/476 who was rejected.


