### PR TITLE
fix: avoid throw for invalid cases when not needed

### DIFF
--- a/benchmarks/bench-inc.js
+++ b/benchmarks/bench-inc.js
@@ -1,23 +1,23 @@
 'use strict'
 
 const Benchmark = require('benchmark')
-const parse = require('../functions/parse')
-const validVersions = require('../test/fixtures/valid-versions')
 const invalidVersions = require('../test/fixtures/invalid-versions')
+const inc = require('../functions/inc')
+const validVersions = require('../test/fixtures/valid-versions')
 const suite = new Benchmark.Suite()
 
 const cases = validVersions.map(invalid => invalid[0])
 const invalidCases = invalidVersions.map(invalid => invalid[0])
 
 for (const test of cases) {
-  suite.add(`parse(${test})`, function () {
-    parse(test)
+  suite.add(`inc(${test})`, function () {
+    inc(test, 'release')
   })
 }
 
 for (const test of invalidCases) {
-  suite.add(`invalid parse(${test})`, function () {
-    parse(test)
+  suite.add(`invalid inc(${test})`, function () {
+    inc(test, 'release')
   })
 }
 

--- a/benchmarks/bench-valid.js
+++ b/benchmarks/bench-valid.js
@@ -1,23 +1,23 @@
 'use strict'
 
 const Benchmark = require('benchmark')
-const parse = require('../functions/parse')
-const validVersions = require('../test/fixtures/valid-versions')
 const invalidVersions = require('../test/fixtures/invalid-versions')
+const valid = require('../functions/valid')
+const validVersions = require('../test/fixtures/valid-versions')
 const suite = new Benchmark.Suite()
 
 const cases = validVersions.map(invalid => invalid[0])
 const invalidCases = invalidVersions.map(invalid => invalid[0])
 
 for (const test of cases) {
-  suite.add(`parse(${test})`, function () {
-    parse(test)
+  suite.add(`valid(${test})`, function () {
+    valid(test)
   })
 }
 
 for (const test of invalidCases) {
-  suite.add(`invalid parse(${test})`, function () {
-    parse(test)
+  suite.add(`invalid valid(${test})`, function () {
+    valid(test)
   })
 }
 

--- a/classes/semver.js
+++ b/classes/semver.js
@@ -6,6 +6,15 @@ const { safeRe: re, t } = require('../internal/re')
 
 const parseOptions = require('../internal/parse-options')
 const { compareIdentifiers } = require('../internal/identifiers')
+
+function handleErrorOnSemver (semver, errorMessage, noThrow) {
+  if (!noThrow) {
+    throw new TypeError(errorMessage)
+  } else {
+    semver.errorMessage = errorMessage
+  }
+}
+
 class SemVer {
   constructor (version, options) {
     options = parseOptions(options)
@@ -18,13 +27,11 @@ class SemVer {
         version = version.version
       }
     } else if (typeof version !== 'string') {
-      throw new TypeError(`Invalid version. Must be a string. Got type "${typeof version}".`)
+      return handleErrorOnSemver(this, `Invalid version. Must be a string. Got type "${typeof version}".`, options.noThrow)
     }
 
     if (version.length > MAX_LENGTH) {
-      throw new TypeError(
-        `version is longer than ${MAX_LENGTH} characters`
-      )
+      return handleErrorOnSemver(this, `version is longer than ${MAX_LENGTH} characters`, options.noThrow)
     }
 
     debug('SemVer', version, options)
@@ -37,7 +44,7 @@ class SemVer {
     const m = version.trim().match(options.loose ? re[t.LOOSE] : re[t.FULL])
 
     if (!m) {
-      throw new TypeError(`Invalid Version: ${version}`)
+      return handleErrorOnSemver(this, `Invalid Version: ${version}`, options.noThrow)
     }
 
     this.raw = version
@@ -48,15 +55,15 @@ class SemVer {
     this.patch = +m[3]
 
     if (this.major > MAX_SAFE_INTEGER || this.major < 0) {
-      throw new TypeError('Invalid major version')
+      return handleErrorOnSemver(this, 'Invalid major version', options.noThrow)
     }
 
     if (this.minor > MAX_SAFE_INTEGER || this.minor < 0) {
-      throw new TypeError('Invalid minor version')
+      return handleErrorOnSemver(this, 'Invalid minor version', options.noThrow)
     }
 
     if (this.patch > MAX_SAFE_INTEGER || this.patch < 0) {
-      throw new TypeError('Invalid patch version')
+      return handleErrorOnSemver(this, 'Invalid patch version', options.noThrow)
     }
 
     // numberify any prerelease numeric ids

--- a/functions/inc.js
+++ b/functions/inc.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const SemVer = require('../classes/semver')
+const parseOptions = require('../internal/parse-options')
+const parse = require('./parse')
 
 const inc = (version, release, options, identifier, identifierBase) => {
   if (typeof (options) === 'string') {
@@ -9,11 +11,21 @@ const inc = (version, release, options, identifier, identifierBase) => {
     options = undefined
   }
 
+  const parsedOptions = parseOptions(options)
+  const parsed = parse(
+    version instanceof SemVer ? version.version : version,
+    parsedOptions.noThrow ? parsedOptions : {
+      ...parsedOptions,
+      noThrow: true,
+    }
+  )
+
+  if (parsed === null) {
+    return null
+  }
+
   try {
-    return new SemVer(
-      version instanceof SemVer ? version.version : version,
-      options
-    ).inc(release, identifier, identifierBase).version
+    return parsed.inc(release, identifier, identifierBase).version
   } catch (er) {
     return null
   }

--- a/functions/parse.js
+++ b/functions/parse.js
@@ -1,18 +1,26 @@
 'use strict'
 
 const SemVer = require('../classes/semver')
+const parseOptions = require('../internal/parse-options')
 const parse = (version, options, throwErrors = false) => {
   if (version instanceof SemVer) {
     return version
   }
-  try {
-    return new SemVer(version, options)
-  } catch (er) {
+
+  const parsedOptions = parseOptions(options)
+  const parsed = new SemVer(version, parsedOptions.noThrow ? parsedOptions : {
+    ...parsedOptions,
+    noThrow: true,
+  })
+
+  if (parsed.errorMessage) {
     if (!throwErrors) {
       return null
     }
-    throw er
+    throw new TypeError(parsed.errorMessage)
   }
+
+  return parsed
 }
 
 module.exports = parse

--- a/test/classes/semver.js
+++ b/test/classes/semver.js
@@ -97,6 +97,19 @@ test('invalid version numbers', (t) => {
   t.end()
 })
 
+test('invalid version numbers without throw', (t) => {
+  ['1.2.3.4', 'NOT VALID', 1.2, null, 'Infinity.NaN.Infinity'].forEach((v) => {
+    const parsed = new SemVer(v, undefined, false)
+
+    t.strictSame(parsed.errorMessage, typeof v === 'string'
+      ? `Invalid Version: ${v}`
+      : `Invalid version. Must be a string. Got type "${typeof v}".`
+    )
+  })
+
+  t.end()
+})
+
 test('incrementing', t => {
   t.plan(increments.length)
   increments.forEach(([

--- a/test/functions/inc.js
+++ b/test/functions/inc.js
@@ -8,7 +8,7 @@ const increments = require('../fixtures/increments.js')
 test('increment versions test', (t) => {
   increments.forEach(([pre, what, wanted, options, id, base]) => {
     const found = inc(pre, what, options, id, base)
-    const cmd = `inc(${pre}, ${what}, ${id}, ${base})`
+    const cmd = `inc(${pre}, ${what}, ${options}, ${id}, ${base})`
     t.equal(found, wanted, `${cmd} === ${wanted}`)
 
     const parsed = parse(pre, options)
@@ -41,6 +41,19 @@ test('increment versions test', (t) => {
     } else {
       t.equal(parsed, null)
     }
+  })
+
+  t.end()
+})
+
+test('special increment version test', (t) => {
+  [
+    ['1.2.3', 'prepatch', '1.2.4-foo.1', 'foo', '1', undefined],
+    ['1.2.3', 'prepatch', '1.2.4-foo.1', {}, 'foo', '1'],
+  ].forEach(([pre, what, wanted, options, id, base]) => {
+    const found = inc(pre, what, options, id, base)
+    const cmd = `inc(${pre}, ${what}, ${options}, ${id}, ${base})`
+    t.equal(found, wanted, `${cmd} === ${wanted}`)
   })
 
   t.end()


### PR DESCRIPTION
Hey, how you doing?

I notice some cases where we don't want to throw when instantiating the `semver`, for those cases, I added a property to `semver` instead of throwing an error since this is an expensive operation on node.

Old for `bench-parse`:

```
inc(1.0.0) x 225,005 ops/sec ±2.02% (73 runs sampled)
inc(2.1.0) x 207,920 ops/sec ±0.69% (98 runs sampled)
inc(3.2.1) x 204,846 ops/sec ±1.11% (96 runs sampled)
inc(v1.2.3) x 179,107 ops/sec ±0.76% (95 runs sampled)
inc(1.2.3-0) x 2,507,827 ops/sec ±0.63% (95 runs sampled)
inc(1.2.3-123) x 2,040,282 ops/sec ±0.29% (96 runs sampled)
inc(1.2.3-1.2.3) x 1,632,962 ops/sec ±0.26% (93 runs sampled)
inc(1.2.3-1a) x 2,243,061 ops/sec ±0.19% (96 runs sampled)
inc(1.2.3-a1) x 2,263,182 ops/sec ±0.20% (97 runs sampled)
inc(1.2.3-alpha) x 2,216,367 ops/sec ±0.21% (96 runs sampled)
inc(1.2.3-alpha.1) x 1,767,612 ops/sec ±0.29% (98 runs sampled)
inc(1.2.3-alpha-1) x 2,175,641 ops/sec ±0.25% (95 runs sampled)
inc(1.2.3-alpha-.-beta) x 1,689,913 ops/sec ±0.22% (97 runs sampled)
inc(1.2.3+456) x 140,200 ops/sec ±0.56% (93 runs sampled)
inc(1.2.3+build) x 139,831 ops/sec ±0.47% (97 runs sampled)
inc(1.2.3+new-build) x 139,792 ops/sec ±0.44% (99 runs sampled)
inc(1.2.3+build.1) x 139,318 ops/sec ±0.39% (99 runs sampled)
inc(1.2.3+build.1a) x 138,640 ops/sec ±0.48% (98 runs sampled)
inc(1.2.3+build.a1) x 138,540 ops/sec ±0.39% (97 runs sampled)
inc(1.2.3+build.alpha) x 138,011 ops/sec ±0.44% (98 runs sampled)
inc(1.2.3+build.alpha.beta) x 136,775 ops/sec ±0.53% (95 runs sampled)
inc(1.2.3-alpha+build) x 1,700,055 ops/sec ±0.12% (99 runs sampled)
invalid inc(111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111.0.0) x 176,696 ops/sec ±0.68% (94 runs sampled)
invalid inc(90071992547409910.0.0) x 145,420 ops/sec ±0.56% (96 runs sampled)
invalid inc(0.90071992547409910.0) x 141,811 ops/sec ±0.39% (100 runs sampled)
invalid inc(0.0.90071992547409910) x 136,328 ops/sec ±0.61% (92 runs sampled)
invalid inc(hello, world) x 158,965 ops/sec ±0.62% (95 runs sampled)
invalid inc(hello, world) x 159,619 ops/sec ±0.59% (96 runs sampled)
invalid inc(xyz) x 159,924 ops/sec ±0.45% (100 runs sampled)
invalid inc(/a regexp/) x 174,861 ops/sec ±0.45% (92 runs sampled)
invalid inc(/1.2.3/) x 170,926 ops/sec ±0.56% (93 runs sampled)
invalid inc(1.2.3) x 174,531 ops/sec ±0.53% (97 runs sampled)
```

Now:

```
inc(1.0.0) x 220,004 ops/sec ±2.08% (71 runs sampled)
inc(2.1.0) x 203,418 ops/sec ±0.65% (96 runs sampled)
inc(3.2.1) x 204,638 ops/sec ±0.84% (99 runs sampled)
inc(v1.2.3) x 183,902 ops/sec ±0.57% (96 runs sampled)
inc(1.2.3-0) x 2,355,120 ops/sec ±0.32% (92 runs sampled)
inc(1.2.3-123) x 1,892,798 ops/sec ±0.26% (94 runs sampled)
inc(1.2.3-1.2.3) x 1,547,679 ops/sec ±0.31% (98 runs sampled)
inc(1.2.3-1a) x 2,177,573 ops/sec ±0.29% (98 runs sampled)
inc(1.2.3-a1) x 2,216,342 ops/sec ±0.18% (98 runs sampled)
inc(1.2.3-alpha) x 2,148,186 ops/sec ±0.30% (94 runs sampled)
inc(1.2.3-alpha.1) x 1,641,404 ops/sec ±0.19% (95 runs sampled)
inc(1.2.3-alpha-1) x 2,153,099 ops/sec ±0.19% (96 runs sampled)
inc(1.2.3-alpha-.-beta) x 1,651,880 ops/sec ±0.22% (98 runs sampled)
inc(1.2.3+456) x 143,325 ops/sec ±0.42% (99 runs sampled)
inc(1.2.3+build) x 142,020 ops/sec ±0.53% (91 runs sampled)
inc(1.2.3+new-build) x 141,831 ops/sec ±0.41% (98 runs sampled)
inc(1.2.3+build.1) x 141,295 ops/sec ±0.42% (98 runs sampled)
inc(1.2.3+build.1a) x 141,597 ops/sec ±0.46% (96 runs sampled)
inc(1.2.3+build.a1) x 141,936 ops/sec ±0.40% (98 runs sampled)
inc(1.2.3+build.alpha) x 141,680 ops/sec ±0.44% (97 runs sampled)
inc(1.2.3+build.alpha.beta) x 141,003 ops/sec ±0.41% (100 runs sampled)
inc(1.2.3-alpha+build) x 1,657,613 ops/sec ±0.17% (96 runs sampled)
invalid inc(111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111.0.0) x 33,693,858 ops/sec ±1.06% (91 runs sampled)
invalid inc(90071992547409910.0.0) x 4,140,107 ops/sec ±0.34% (93 runs sampled)
invalid inc(0.90071992547409910.0) x 4,202,449 ops/sec ±0.54% (96 runs sampled)
invalid inc(0.0.90071992547409910) x 4,074,528 ops/sec ±0.37% (94 runs sampled)
invalid inc(hello, world) x 16,226,916 ops/sec ±0.62% (92 runs sampled)
invalid inc(hello, world) x 16,308,847 ops/sec ±0.56% (98 runs sampled)
invalid inc(xyz) x 16,368,938 ops/sec ±0.58% (97 runs sampled)
invalid inc(/a regexp/) x 26,658,694 ops/sec ±0.58% (96 runs sampled)
invalid inc(/1.2.3/) x 26,474,634 ops/sec ±0.73% (97 runs sampled)
invalid inc(1.2.3) x 26,354,579 ops/sec ±0.82% (96 runs sampled)
```

I'm not sure if this is something you guys are willing to do (adding a new property and have the object partially dead), so l will keep this as draft for now.