### PR TITLE
x-range partial version build metadata support

### DIFF
--- a/classes/range.js
+++ b/classes/range.js
@@ -33,7 +33,7 @@ class Range {
     // First reduce all whitespace as much as possible so we do not have to rely
     // on potentially slow regexes like \s*. This is then stored and used for
     // future error messages as well.
-    this.raw = range.trim().replace(SPACE_CHARACTERS, ' ')
+    this.raw = range.trim().replace(SPACE_CHARACTERS, ' ').replace(/\+[^ ]*/g, '')
 
     // First, split on ||
     this.set = this.raw
@@ -398,6 +398,11 @@ const replaceXRange = (comp, options) => {
     const xm = xM || isX(m)
     const xp = xm || isX(p)
     const anyX = xp
+
+    // Disallow prerelease with any X-range or partial version
+    if ((xM || xm || xp) && pr) {
+      throw new TypeError('Prerelease not allowed with X-ranges or partial versions')
+    }
 
     if (gtlt === '=' && anyX) {
       gtlt = ''

--- a/test/classes/range.js
+++ b/test/classes/range.js
@@ -126,3 +126,53 @@ test('cache', (t) => {
   t.equal(r2.set[0][cached], true) // Will be true, showing it's cached.
   t.end()
 })
+
+test('Build metadata is allowed and ignored for X-ranges and partials', t => {
+  const buildCases = [
+    '1.x.x+build >2.x.x+build',
+    '>=1.x.x+build <2.x.x+build',
+    '1.x.x+build || 2.x.x+build',
+    '1.x.x+build.123',
+    '1.x.x+meta-data',
+    '1.x.x+build.123 >2.x.x+meta-data',
+    '1.x.x+build <2.x.x+meta',
+    '>1.x.x+build <=2.x.x+meta',
+    ' 1.x.x+build   >2.x.x+build  ',
+  ]
+  t.plan(buildCases.length)
+  buildCases.forEach(range => {
+    t.doesNotThrow(() => new Range(range), `${range} should not throw`)
+  })
+})
+
+test('Build metadata with prerelease in X-ranges/partials throws', t => {
+  const cases = [
+    '1.x.x-alpha+build',
+    '1.x-alpha+build',
+    '1-alpha+build',
+    '>1.x.x-alpha+build',
+    '>=1.x.x-alpha+build <2.x.x+build',
+    '1.x.x-alpha+build || 2.x.x+build',
+  ]
+  t.plan(cases.length)
+  cases.forEach(range => {
+    t.throws(() => new Range(range), TypeError, `${range} should throw TypeError`)
+  })
+})
+
+test('Prerelease is NOT allowed with X-ranges or partials', t => {
+  const prereleaseCases = [
+    '1.x-alpha',
+    '1-alpha',
+    '1.x.x-alpha',
+    '>1.x-alpha',
+    '>1-alpha',
+    '>1.x.x-alpha',
+    '1.x.x-alpha <2.x.x-alpha',
+    '>1.x.x-alpha <=2.x-alpha',
+  ]
+  t.plan(prereleaseCases.length)
+  prereleaseCases.forEach(range => {
+    t.throws(() => new Range(range), TypeError, `${range} should throw TypeError`)
+  })
+})


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Supporting for partial version and x-range for build metadata.
`bin/semver.js 1.3.4 -r ">=1.x+build <2.x+build"` will work.

Also checking and removing support for x-range pre-release.
`bin/semver.js 1.3.4 -r ">=1.x.x-alpha <2.x+build"` will not work.

## References

  Related to #509 
  
