### PR TITLE
fix: faster paths for compare

### DIFF
--- a/benchmarks/bench-compare.js
+++ b/benchmarks/bench-compare.js
@@ -4,43 +4,13 @@ const Benchmark = require('benchmark')
 const SemVer = require('../classes/semver')
 const suite = new Benchmark.Suite()
 
-const versions = ['1.0.3', '2.2.2', '2.3.0']
-const versionToCompare = '1.0.2'
-const option1 = { includePrelease: true }
-const option2 = { includePrelease: true, loose: true }
-const option3 = { includePrelease: true, loose: true, rtl: true }
+const comparisons = require('../test/fixtures/comparisons')
 
-for (const version of versions) {
-  suite.add(`compare ${version} to ${versionToCompare}`, function () {
-    const semver = new SemVer(version)
-    semver.compare(versionToCompare)
+for (const [v0, v1] of comparisons) {
+  suite.add(`compare ${v0} to ${v1}`, function () {
+    const semver = new SemVer(v0)
+    semver.compare(v1)
   })
-}
-
-for (const version of versions) {
-  suite.add(
-    `compare ${version} to ${versionToCompare} with option (${JSON.stringify(option1)})`,
-    function () {
-      const semver = new SemVer(version, option1)
-      semver.compare(versionToCompare)
-    })
-}
-
-for (const version of versions) {
-  suite.add(`compare ${version} to ${versionToCompare} with option (${JSON.stringify(option2)})`,
-    function () {
-      const semver = new SemVer(version, option2)
-      semver.compare(versionToCompare)
-    })
-}
-
-for (const version of versions) {
-  suite.add(
-    `compare ${version} to ${versionToCompare} with option (${JSON.stringify(option3)})`,
-    function () {
-      const semver = new SemVer(version, option3)
-      semver.compare(versionToCompare)
-    })
 }
 
 suite

--- a/benchmarks/bench-parse.js
+++ b/benchmarks/bench-parse.js
@@ -2,21 +2,20 @@
 
 const Benchmark = require('benchmark')
 const parse = require('../functions/parse')
-const { MAX_SAFE_INTEGER } = require('../internal/constants')
 const suite = new Benchmark.Suite()
 
-const cases = ['1.2.1', '1.2.2-4', '1.2.3-pre']
-const invalidCases = [`${MAX_SAFE_INTEGER}0.0.0`, 'hello, world', 'xyz']
+const cases = require(`../test/fixtures/valid-versions`)
+const invalidCases = require(`../test/fixtures/invalid-versions`)
 
 for (const test of cases) {
-  suite.add(`parse(${test})`, function () {
-    parse(test)
+  suite.add(`parse(${test[0]})`, function () {
+    parse(test[0])
   })
 }
 
 for (const test of invalidCases) {
-  suite.add(`invalid parse(${test})`, function () {
-    parse(test)
+  suite.add(`invalid parse(${test[0]})`, function () {
+    parse(test[0])
   })
 }
 

--- a/classes/semver.js
+++ b/classes/semver.js
@@ -111,11 +111,25 @@ class SemVer {
       other = new SemVer(other, this.options)
     }
 
-    return (
-      compareIdentifiers(this.major, other.major) ||
-      compareIdentifiers(this.minor, other.minor) ||
-      compareIdentifiers(this.patch, other.patch)
-    )
+    if (this.major < other.major) {
+      return -1
+    }
+    if (this.major > other.major) {
+      return 1
+    }
+    if (this.minor < other.minor) {
+      return -1
+    }
+    if (this.minor > other.minor) {
+      return 1
+    }
+    if (this.patch < other.patch) {
+      return -1
+    }
+    if (this.patch > other.patch) {
+      return 1
+    }
+    return 0
   }
 
   comparePre (other) {

--- a/internal/identifiers.js
+++ b/internal/identifiers.js
@@ -2,6 +2,10 @@
 
 const numeric = /^[0-9]+$/
 const compareIdentifiers = (a, b) => {
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a === b ? 0 : a < b ? -1 : 1
+  }
+
   const anum = numeric.test(a)
   const bnum = numeric.test(b)
 

--- a/test/internal/identifiers.js
+++ b/test/internal/identifiers.js
@@ -8,6 +8,7 @@ test('rcompareIdentifiers and compareIdentifiers', (t) => {
     ['1', '2'],
     ['alpha', 'beta'],
     ['0', 'beta'],
+    [1, 2],
   ]
   set.forEach((ab) => {
     const a = ab[0]
@@ -17,5 +18,7 @@ test('rcompareIdentifiers and compareIdentifiers', (t) => {
   })
   t.equal(compareIdentifiers('0', '0'), 0)
   t.equal(rcompareIdentifiers('0', '0'), 0)
+  t.equal(compareIdentifiers(1, 1), 0)
+  t.equal(rcompareIdentifiers(1, 1), 0)
   t.end()
 })


### PR DESCRIPTION
A simple change to avoid Regex when we already know both values are number.

```diff
-compare 0.0.0 to 0.0.0-foo x 2,281,198 ops/sec ±0.36% (98 runs sampled)
+compare 0.0.0 to 0.0.0-foo x 3,020,851 ops/sec ±0.38% (99 runs sampled)
-compare 0.0.1 to 0.0.0 x 3,874,114 ops/sec ±0.53% (94 runs sampled)
+compare 0.0.1 to 0.0.0 x 5,925,824 ops/sec ±0.28% (99 runs sampled)
-compare 1.0.0 to 0.9.9 x 4,764,980 ops/sec ±0.62% (94 runs sampled)
+compare 1.0.0 to 0.9.9 x 5,837,427 ops/sec ±0.38% (97 runs sampled)
-compare 0.10.0 to 0.9.0 x 3,799,602 ops/sec ±0.49% (94 runs sampled)
+compare 0.10.0 to 0.9.0 x 5,390,337 ops/sec ±0.40% (98 runs sampled)
-compare 0.99.0 to 0.10.0 x 3,457,321 ops/sec ±0.54% (94 runs sampled)
+compare 0.99.0 to 0.10.0 x 4,729,216 ops/sec ±0.25% (101 runs sampled)
-compare 2.0.0 to 1.2.3 x 4,784,659 ops/sec ±0.68% (92 runs sampled)
+compare 2.0.0 to 1.2.3 x 5,773,274 ops/sec ±0.35% (94 runs sampled)
-compare v0.0.0 to 0.0.0-foo x 2,266,819 ops/sec ±0.76% (93 runs sampled)
+compare v0.0.0 to 0.0.0-foo x 3,074,139 ops/sec ±0.43% (96 runs sampled)
-compare v0.0.1 to 0.0.0 x 3,798,026 ops/sec ±0.75% (93 runs sampled)
+compare v0.0.1 to 0.0.0 x 5,824,666 ops/sec ±0.38% (97 runs sampled)
-compare v1.0.0 to 0.9.9 x 4,704,188 ops/sec ±0.97% (91 runs sampled)
+compare v1.0.0 to 0.9.9 x 5,727,448 ops/sec ±0.43% (98 runs sampled)
-compare v0.10.0 to 0.9.0 x 3,785,330 ops/sec ±0.57% (96 runs sampled)
+compare v0.10.0 to 0.9.0 x 5,385,605 ops/sec ±0.22% (101 runs sampled)
-compare v0.99.0 to 0.10.0 x 3,444,526 ops/sec ±0.57% (92 runs sampled)
+compare v0.99.0 to 0.10.0 x 4,847,083 ops/sec ±0.35% (97 runs sampled)
-compare v2.0.0 to 1.2.3 x 4,795,300 ops/sec ±0.57% (94 runs sampled)
+compare v2.0.0 to 1.2.3 x 5,754,048 ops/sec ±0.32% (96 runs sampled)
-compare 0.0.0 to v0.0.0-foo x 2,299,780 ops/sec ±0.44% (94 runs sampled)
+compare 0.0.0 to v0.0.0-foo x 2,954,600 ops/sec ±0.36% (97 runs sampled)
-compare 0.0.1 to v0.0.0 x 3,980,408 ops/sec ±0.48% (97 runs sampled)
+compare 0.0.1 to v0.0.0 x 5,934,794 ops/sec ±0.34% (94 runs sampled)
-compare 1.0.0 to v0.9.9 x 4,840,697 ops/sec ±0.65% (97 runs sampled)
+compare 1.0.0 to v0.9.9 x 5,927,552 ops/sec ±0.63% (91 runs sampled)
-compare 0.10.0 to v0.9.0 x 3,765,578 ops/sec ±0.73% (99 runs sampled)
+compare 0.10.0 to v0.9.0 x 5,208,391 ops/sec ±0.27% (93 runs sampled)
-compare 0.99.0 to v0.10.0 x 3,464,883 ops/sec ±0.55% (96 runs sampled)
+compare 0.99.0 to v0.10.0 x 4,751,421 ops/sec ±0.25% (100 runs sampled)
-compare 2.0.0 to v1.2.3 x 4,884,354 ops/sec ±0.66% (94 runs sampled)
+compare 2.0.0 to v1.2.3 x 5,888,450 ops/sec ±0.38% (91 runs sampled)
-compare 1.2.3 to 1.2.3-asdf x 2,225,975 ops/sec ±0.65% (95 runs sampled)
+compare 1.2.3 to 1.2.3-asdf x 3,042,336 ops/sec ±0.42% (97 runs sampled)
-compare 1.2.3 to 1.2.3-4 x 2,570,852 ops/sec ±0.38% (96 runs sampled)
+compare 1.2.3 to 1.2.3-4 x 3,520,964 ops/sec ±0.29% (95 runs sampled)
-compare 1.2.3 to 1.2.3-4-foo x 2,117,202 ops/sec ±0.36% (97 runs sampled)
+compare 1.2.3 to 1.2.3-4-foo x 2,846,106 ops/sec ±0.49% (95 runs sampled)
-compare 1.2.3-5-foo to 1.2.3-5 x 1,541,290 ops/sec ±0.79% (99 runs sampled)
+compare 1.2.3-5-foo to 1.2.3-5 x 1,803,126 ops/sec ±0.35% (93 runs sampled)
-compare 1.2.3-5 to 1.2.3-4 x 1,652,015 ops/sec ±0.39% (97 runs sampled)
+compare 1.2.3-5 to 1.2.3-4 x 2,351,313 ops/sec ±0.49% (93 runs sampled)
-compare 1.2.3-5-foo to 1.2.3-5-Foo x 1,375,682 ops/sec ±0.28% (99 runs sampled)
+compare 1.2.3-5-foo to 1.2.3-5-Foo x 1,773,293 ops/sec ±0.26% (97 runs sampled)
-compare 3.0.0 to 2.7.2+asdf x 3,175,150 ops/sec ±0.35% (100 runs sampled)
+compare 3.0.0 to 2.7.2+asdf x 4,535,879 ops/sec ±0.40% (95 runs sampled)
-compare 1.2.3-a.10 to 1.2.3-a.5 x 1,114,865 ops/sec ±0.15% (97 runs sampled)
+compare 1.2.3-a.10 to 1.2.3-a.5 x 1,368,780 ops/sec ±0.19% (99 runs sampled)
-compare 1.2.3-a.b to 1.2.3-a.5 x 1,151,804 ops/sec ±0.34% (98 runs sampled)
+compare 1.2.3-a.b to 1.2.3-a.5 x 1,339,954 ops/sec ±0.32% (97 runs sampled)
-compare 1.2.3-a.b to 1.2.3-a x 1,456,826 ops/sec ±0.32% (93 runs sampled)
+compare 1.2.3-a.b to 1.2.3-a x 1,826,409 ops/sec ±0.74% (97 runs sampled)
-compare 1.2.3-a.b.c.10.d.5 to 1.2.3-a.b.c.5.d.100 x 774,897 ops/sec ±0.79% (101 runs sampled)
+compare 1.2.3-a.b.c.10.d.5 to 1.2.3-a.b.c.5.d.100 x 870,045 ops/sec ±0.34% (95 runs sampled)
-compare 1.2.3-r2 to 1.2.3-r100 x 1,505,620 ops/sec ±0.15% (100 runs sampled)
+compare 1.2.3-r2 to 1.2.3-r100 x 1,788,234 ops/sec ±0.53% (94 runs sampled)
-compare 1.2.3-r100 to 1.2.3-R2 x 1,494,922 ops/sec ±0.15% (98 runs sampled)
+compare 1.2.3-r100 to 1.2.3-R2 x 1,769,180 ops/sec ±0.60% (93 runs sampled)
```