### PR TITLE
chore: reorder parameters in invalid-versions.js test

### DIFF
--- a/test/fixtures/invalid-versions.js
+++ b/test/fixtures/invalid-versions.js
@@ -9,7 +9,7 @@ module.exports = [
   [`0.${MAX_SAFE_INTEGER}0.0`, 'too big'],
   [`0.0.${MAX_SAFE_INTEGER}0`, 'too big'],
   ['hello, world', 'not a version'],
-  ['hello, world', true, 'even loose, its still junk'],
+  ['hello, world', 'even loose, its still junk', true],
   ['xyz', 'even loose as an opt, same', { loose: true }],
   [/a regexp/, 'regexp is not a string'],
   [/1.2.3/, 'semver-ish regexp is not a string'],


### PR DESCRIPTION
This test puts true in the `t.throws` "message" field which is incorrect.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
