### PR TITLE
fix(cli): pass options to semver.valid() for loose version validation

### DIFF
--- a/bin/semver.js
+++ b/bin/semver.js
@@ -105,7 +105,7 @@ const main = () => {
   versions = versions.map((v) => {
     return coerce ? (semver.coerce(v, options) || { version: v }).version : v
   }).filter((v) => {
-    return semver.valid(v)
+    return semver.valid(v, options)
   })
   if (!versions.length) {
     return fail()

--- a/tap-snapshots/test/bin/semver.js.test.cjs
+++ b/tap-snapshots/test/bin/semver.js.test.cjs
@@ -348,7 +348,7 @@ Object {
 }
 `
 
-exports[`test/bin/semver.js TAP inc tests > -i release 1.0.0-pre`] = `
+exports[`test/bin/semver.js TAP inc tests > -i release 1.0.0-pre 1`] = `
 Object {
   "code": 0,
   "err": "",
@@ -454,11 +454,24 @@ Object {
 }
 `
 
+exports[`test/bin/semver.js TAP sorting and filtering > 1.2.3beta -l 1`] = `
+Object {
+  "code": 0,
+  "err": "",
+  "out": "1.2.3-beta\\n",
+  "signal": null,
+}
+`
+
 exports[`test/bin/semver.js TAP sorting and filtering > 1.2.3foo 1.2.3-bar -l 1`] = `
 Object {
   "code": 0,
   "err": "",
-  "out": "1.2.3-bar\\n",
+  "out": String(
+    1.2.3-bar
+    1.2.3-foo
+    
+  ),
   "signal": null,
 }
 `
@@ -477,6 +490,7 @@ Object {
   "code": 0,
   "err": "",
   "out": String(
+    2.0.0-asdf
     2.3.4-beta
     2.3.4
     

--- a/test/bin/semver.js
+++ b/test/bin/semver.js
@@ -33,6 +33,7 @@ t.test('inc tests', t => Promise.all([
   ['-i', 'premajor', '1.0.0', '--preid=beta', '-n', '1'],
   ['-i', 'premajor', '1.0.0', '--preid=beta', '-n', 'false'],
   ['-i', '1.2.3'],
+  ['-i', 'release', '1.0.0-pre'],
 ].map(args => t.resolveMatchSnapshot(run(args), args.join(' ')))))
 
 t.test('help output', t => Promise.all([
@@ -49,6 +50,7 @@ t.test('sorting and filtering', t => Promise.all([
   ['1.2.3', '-v', '3.2.1', '--version', '2.3.4', '-rv'],
   ['1.2.3foo', '1.2.3-bar'],
   ['1.2.3foo', '1.2.3-bar', '-l'],
+  ['1.2.3beta', '-l'],
   ['1.2.3', '3.2.1', '-r', '2.x', '2.3.4'],
   ['1.2.3', '3.2.1', '2.3.4', '2.3.4-beta', '2.0.0asdf', '-r', '2.x'],
   ['1.2.3', '3.2.1', '2.3.4', '2.3.4-beta', '2.0.0asdf', '-r', '2.x', '-p'],


### PR DESCRIPTION
## Summary

The `--loose` flag was not being applied when validating input versions.

## Problem

```bash
$ semver 1.2.3beta -l
# Expected: 1.2.3-beta (exit 0)
# Actual: exit 1
```

The `options` object (containing `loose: true`) was already being passed to `coerce()` and `satisfies()`, but the `filter()` validation step was calling `semver.valid(v)` without it.

## Fix

```diff
-  return semver.valid(v)
+  return semver.valid(v, options)
```

## Test plan

- Added regression test for `1.2.3beta -l`
- All existing tests pass
- 100% code coverage maintained