### PR TITLE
feat: Add `truncate` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ const semverCompareLoose = require('semver/functions/compare-loose')
 const semverCompareBuild = require('semver/functions/compare-build')
 const semverSort = require('semver/functions/sort')
 const semverRsort = require('semver/functions/rsort')
+const semverTruncate = require('semver/functions/truncate')
 
 // low-level comparators between versions
 const semverGt = require('semver/functions/gt')
@@ -456,6 +457,12 @@ strings that they parse.
   or comparators intersect.
 * `parse(v)`: Attempt to parse a string as a semantic version, returning either
   a `SemVer` object or `null`.
+* `truncate(v, releaseType)`: Return the version with components _lower_
+  than `releaseType` dropped off, e.g.:
+  * `major` removes build & prerelease info and sets minor & patch to 0.
+  * `minor` removes build & prerelease info, and sets patch to 0
+  * `patch` removes build & prerelease info
+  * All prerelease types remove build info only
 
 ### Comparison
 
@@ -657,6 +664,7 @@ The following modules are available:
 * `require('semver/functions/rsort')`
 * `require('semver/functions/satisfies')`
 * `require('semver/functions/sort')`
+* `require('semver/functions.truncate')`
 * `require('semver/functions/valid')`
 * `require('semver/ranges/gtr')`
 * `require('semver/ranges/intersects')`

--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ The following modules are available:
 * `require('semver/functions/rsort')`
 * `require('semver/functions/satisfies')`
 * `require('semver/functions/sort')`
-* `require('semver/functions.truncate')`
+* `require('semver/functions/truncate')`
 * `require('semver/functions/valid')`
 * `require('semver/ranges/gtr')`
 * `require('semver/ranges/intersects')`

--- a/functions/truncate.js
+++ b/functions/truncate.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const SemVer = require('../classes/semver')
+const constants = require('../internal/constants')
+
+const truncate = (version, releaseType, options) => {
+  // if (typeof (options) === 'string') {
+  //   options = undefined
+  // }
+
+  if (!constants.RELEASE_TYPES.includes(releaseType)) {
+    return null
+  }
+
+  try {
+    const currentVersion = new SemVer(
+      version instanceof SemVer ? version.version : version,
+      options
+    )
+
+    currentVersion.prerelease = []
+
+    switch (releaseType) {
+      case 'major':
+        currentVersion.minor = 0
+      // eslint-disable-next-line no-fallthrough -- this is intentional fallthrough
+      case 'minor':
+        currentVersion.patch = 0
+    }
+
+    return currentVersion.format()
+  } catch (er) {
+    return null
+  }
+}
+module.exports = truncate

--- a/functions/truncate.js
+++ b/functions/truncate.js
@@ -3,26 +3,35 @@
 const parse = require('./parse')
 const constants = require('../internal/constants')
 
-const _truncate = (version, releaseType) => {
+const _truncate = (version, truncation) => {
+  if (truncation.startsWith('pre')) {
+    return version.version
+  }
+
   version.prerelease = []
 
-  switch (releaseType) {
+  switch (truncation) {
     case 'major':
       version.minor = 0
-    // eslint-disable-next-line no-fallthrough -- this is intentional fallthrough
+      version.patch = 0
+      break
     case 'minor':
       version.patch = 0
+      break
   }
 
   return version.format()
 }
 
-const truncate = (version, releaseType, options) => {
-  if (!constants.RELEASE_TYPES.includes(releaseType)) {
+const truncate = (version, truncation, options) => {
+  if (!constants.RELEASE_TYPES.includes(truncation)) {
     return null
   }
 
   const parsed = parse(version, options)
-  return parsed && _truncate(parsed, releaseType)
+  return parsed && _truncate(parsed, truncation)
 }
 module.exports = truncate
+
+
+// 1. Should truncate _always_ strip off build info?

--- a/functions/truncate.js
+++ b/functions/truncate.js
@@ -3,8 +3,17 @@
 const parse = require('./parse')
 const constants = require('../internal/constants')
 
-const _truncate = (version, truncation) => {
-  if (truncation.startsWith('pre')) {
+const truncate = (version, truncation, options) => {
+  if (!constants.RELEASE_TYPES.includes(truncation)) {
+    return null
+  }
+
+  const parsed = parse(version, options)
+  return parsed && doTruncation(parsed, truncation)
+}
+
+const doTruncation = (version, truncation) => {
+  if (isPrerelease(truncation)) {
     return version.version
   }
 
@@ -23,15 +32,8 @@ const _truncate = (version, truncation) => {
   return version.format()
 }
 
-const truncate = (version, truncation, options) => {
-  if (!constants.RELEASE_TYPES.includes(truncation)) {
-    return null
-  }
-
-  const parsed = parse(version, options)
-  return parsed && _truncate(parsed, truncation)
+const isPrerelease = (type) => {
+  return type.startsWith('pre')
 }
+
 module.exports = truncate
-
-
-// 1. Should truncate _always_ strip off build info?

--- a/functions/truncate.js
+++ b/functions/truncate.js
@@ -2,14 +2,23 @@
 
 const parse = require('./parse')
 const constants = require('../internal/constants')
+const SemVer = require('../classes/semver')
 
 const truncate = (version, truncation, options) => {
   if (!constants.RELEASE_TYPES.includes(truncation)) {
     return null
   }
 
-  const parsed = parse(version, options)
-  return parsed && doTruncation(parsed, truncation)
+  const clonedVersion = cloneInputVersion(version, options)
+  return clonedVersion && doTruncation(clonedVersion, truncation)
+}
+
+const cloneInputVersion = (version, options) => {
+  const versionStringToParse = (
+    version instanceof SemVer ? version.version : version
+  )
+
+  return parse(versionStringToParse, options)
 }
 
 const doTruncation = (version, truncation) => {

--- a/functions/truncate.js
+++ b/functions/truncate.js
@@ -1,36 +1,28 @@
 'use strict'
 
-const SemVer = require('../classes/semver')
+const parse = require('./parse')
 const constants = require('../internal/constants')
 
-const truncate = (version, releaseType, options) => {
-  // if (typeof (options) === 'string') {
-  //   options = undefined
-  // }
+const _truncate = (version, releaseType) => {
+  version.prerelease = []
 
+  switch (releaseType) {
+    case 'major':
+      version.minor = 0
+    // eslint-disable-next-line no-fallthrough -- this is intentional fallthrough
+    case 'minor':
+      version.patch = 0
+  }
+
+  return version.format()
+}
+
+const truncate = (version, releaseType, options) => {
   if (!constants.RELEASE_TYPES.includes(releaseType)) {
     return null
   }
 
-  try {
-    const currentVersion = new SemVer(
-      version instanceof SemVer ? version.version : version,
-      options
-    )
-
-    currentVersion.prerelease = []
-
-    switch (releaseType) {
-      case 'major':
-        currentVersion.minor = 0
-      // eslint-disable-next-line no-fallthrough -- this is intentional fallthrough
-      case 'minor':
-        currentVersion.patch = 0
-    }
-
-    return currentVersion.format()
-  } catch (er) {
-    return null
-  }
+  const parsed = parse(version, options)
+  return parsed && _truncate(parsed, releaseType)
 }
 module.exports = truncate

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const gte = require('./functions/gte')
 const lte = require('./functions/lte')
 const cmp = require('./functions/cmp')
 const coerce = require('./functions/coerce')
+const truncate = require('./functions/truncate')
 const Comparator = require('./classes/comparator')
 const Range = require('./classes/range')
 const satisfies = require('./functions/satisfies')
@@ -66,6 +67,7 @@ module.exports = {
   lte,
   cmp,
   coerce,
+  truncate,
   Comparator,
   Range,
   satisfies,

--- a/test/fixtures/truncations.js
+++ b/test/fixtures/truncations.js
@@ -1,0 +1,14 @@
+'use strict'
+
+// [version, releaseType, result]
+// truncate(version, type) -> result
+module.exports = [
+  ['1.2.3-foo', 'patch', '1.2.3'],
+  ['1.2.3', 'patch', '1.2.3'],
+  ['1.2.3', 'minor', '1.2.0'],
+  ['1.2.3', 'major', '1.0.0'],
+
+  // invalid inputs
+  ['1.2.3', 'fake', null],
+  ['fake', 'major', null],
+]

--- a/test/fixtures/truncations.js
+++ b/test/fixtures/truncations.js
@@ -11,4 +11,29 @@ module.exports = [
   // invalid inputs
   ['1.2.3', 'fake', null],
   ['fake', 'major', null],
+
+  // additional pre-release, build, and pre+build inputs
+  ['4.5.6-rc2', 'prerelease', '4.5.6-rc2'],
+  ['4.5.6-rc2', 'prepatch', '4.5.6-rc2'],
+  ['4.5.6-rc2', 'preminor', '4.5.6-rc2'],
+  ['4.5.6-rc2', 'premajor', '4.5.6-rc2'],
+  ['4.5.6-rc2', 'patch', '4.5.6'],
+  ['4.5.6-rc2', 'minor', '4.5.0'],
+  ['4.5.6-rc2', 'major', '4.0.0'],
+
+  ['4.5.6+dadb0d', 'prerelease', '4.5.6'],
+  ['4.5.6+dadb0d', 'prepatch', '4.5.6'],
+  ['4.5.6+dadb0d', 'preminor', '4.5.6'],
+  ['4.5.6+dadb0d', 'premajor', '4.5.6'],
+  ['4.5.6+dadb0d', 'patch', '4.5.6'],
+  ['4.5.6+dadb0d', 'minor', '4.5.0'],
+  ['4.5.6+dadb0d', 'major', '4.0.0'],
+
+  ['4.5.6-rc2+dadb0d', 'prerelease', '4.5.6-rc2'],
+  ['4.5.6-rc2+dadb0d', 'prepatch', '4.5.6-rc2'],
+  ['4.5.6-rc2+dadb0d', 'preminor', '4.5.6-rc2'],
+  ['4.5.6-rc2+dadb0d', 'premajor', '4.5.6-rc2'],
+  ['4.5.6-rc2+dadb0d', 'patch', '4.5.6'],
+  ['4.5.6-rc2+dadb0d', 'minor', '4.5.0'],
+  ['4.5.6-rc2+dadb0d', 'major', '4.0.0'],
 ]

--- a/test/functions/truncate.js
+++ b/test/functions/truncate.js
@@ -7,13 +7,13 @@ const truncations = require('../fixtures/truncations.js')
 const validVersions = require('../fixtures/valid-versions.js')
 
 test('truncate fixture versions test', (t) => {
-  truncations.forEach(([pre, truncation, expected, options, id, base]) => {
-    const actual = truncate(pre, truncation, options, id, base)
-    const cmd = `truncate(${pre}, ${truncation}, ${options}, ${id}, ${base})`
+  truncations.forEach(([pre, truncation, expected]) => {
+    const actual = truncate(pre, truncation)
+    const cmd = `truncate(${pre}, ${truncation})`
     t.equal(actual, expected, `${cmd} === ${expected}`)
 
-    const parsed = parse(pre, options)
-    const semverTruncated = truncate(parsed, truncation, options)
+    const parsed = parse(pre)
+    const semverTruncated = truncate(parsed, truncation)
     t.equal(semverTruncated, expected, `${cmd} works on Semver objects`)
   })
 
@@ -30,7 +30,7 @@ test('truncate pre* only removes build info', (t) => {
 
       const cmd = `truncate(${versionToTruncate}, ${what})`
       t.equal(actual, expected, `${cmd} === ${expected}`)
-      t.same(parse(actual).build, [], `${cmd} strips build info `)
+      t.same(parse(actual).build, [], `${cmd} build info should be removed`)
     })
   })
   t.end()

--- a/test/functions/truncate.js
+++ b/test/functions/truncate.js
@@ -13,7 +13,7 @@ test('truncate fixture versions test', (t) => {
     t.equal(actual, expected, `${cmd} === ${expected}`)
 
     const parsed = parse(pre, options)
-    const semverTruncated = truncate(parsed, what, options)
+    const semverTruncated = truncate(parsed, truncation, options)
     t.equal(semverTruncated, expected, `${cmd} works on Semver objects`)
   })
 

--- a/test/functions/truncate.js
+++ b/test/functions/truncate.js
@@ -4,17 +4,34 @@ const { test } = require('tap')
 const truncate = require('../../functions/truncate')
 const parse = require('../../functions/parse')
 const truncations = require('../fixtures/truncations.js')
+const validVersions = require('../fixtures/valid-versions.js')
 
-test('truncate versions test', (t) => {
-  truncations.forEach(([pre, what, wanted, options, id, base]) => {
-    const found = truncate(pre, what, options, id, base)
-    const cmd = `truncate(${pre}, ${what}, ${options}, ${id}, ${base})`
-    t.equal(found, wanted, `${cmd} === ${wanted}`)
+test('truncate fixture versions test', (t) => {
+  truncations.forEach(([pre, truncation, expected, options, id, base]) => {
+    const actual = truncate(pre, truncation, options, id, base)
+    const cmd = `truncate(${pre}, ${truncation}, ${options}, ${id}, ${base})`
+    t.equal(actual, expected, `${cmd} === ${expected}`)
 
     const parsed = parse(pre, options)
     const semverTruncated = truncate(parsed, what, options)
-    t.equal(semverTruncated, wanted, `${cmd} works on Semver objects`)
+    t.equal(semverTruncated, expected, `${cmd} works on Semver objects`)
   })
 
+  t.end()
+})
+
+test('truncate pre* only removes build info', (t) => {
+  ['prerelease', 'prepatch', 'preminor', 'premajor'].forEach(what => {
+    validVersions.forEach((v) => {
+      const versionToTruncate = v[0]
+      const parsed = parse(versionToTruncate)
+      const expected = parsed.version
+      const actual = truncate(versionToTruncate, what)
+
+      const cmd = `truncate(${versionToTruncate}, ${what})`
+      t.equal(actual, expected, `${cmd} === ${expected}`)
+      t.same(parse(actual).build, [], `${cmd} strips build info `)
+    })
+  })
   t.end()
 })

--- a/test/functions/truncate.js
+++ b/test/functions/truncate.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const { test } = require('tap')
+const truncate = require('../../functions/truncate')
+const parse = require('../../functions/parse')
+const truncations = require('../fixtures/truncations.js')
+
+test('truncate versions test', (t) => {
+  truncations.forEach(([pre, what, wanted, options, id, base]) => {
+    const found = truncate(pre, what, options, id, base)
+    const cmd = `truncate(${pre}, ${what}, ${options}, ${id}, ${base})`
+    t.equal(found, wanted, `${cmd} === ${wanted}`)
+
+    const parsed = parse(pre, options)
+    const semverTruncated = truncate(parsed, what, options)
+    t.equal(semverTruncated, wanted, `${cmd} works on Semver objects`)
+  })
+
+  t.end()
+})

--- a/test/functions/truncate.js
+++ b/test/functions/truncate.js
@@ -6,15 +6,23 @@ const parse = require('../../functions/parse')
 const truncations = require('../fixtures/truncations.js')
 const validVersions = require('../fixtures/valid-versions.js')
 
+// Freezing SemVer object inputs to truncate ensures that the truncate function
+// does not mutate them
+const parseAndFreezeSemVerObject = (version) => {
+  const parsed = parse(version)
+  Object.freeze(parsed)
+  return parsed
+}
+
 test('truncate fixture versions test', (t) => {
   truncations.forEach(([pre, truncation, expected]) => {
     const actual = truncate(pre, truncation)
     const cmd = `truncate(${pre}, ${truncation})`
     t.equal(actual, expected, `${cmd} === ${expected}`)
 
-    const parsed = parse(pre)
+    const parsed = parseAndFreezeSemVerObject(pre)
     const semverTruncated = truncate(parsed, truncation)
-    t.equal(semverTruncated, expected, `${cmd} works on Semver objects`)
+    t.equal(semverTruncated, expected, `${cmd} works on Semver object inputs`)
   })
 
   t.end()
@@ -24,7 +32,7 @@ test('truncate pre* only removes build info', (t) => {
   ['prerelease', 'prepatch', 'preminor', 'premajor'].forEach(what => {
     validVersions.forEach((v) => {
       const versionToTruncate = v[0]
-      const parsed = parse(versionToTruncate)
+      const parsed = parseAndFreezeSemVerObject(versionToTruncate)
       const expected = parsed.version
       const actual = truncate(versionToTruncate, what)
 


### PR DESCRIPTION
<!-- What / Why -->
This PR adds a `truncate` function to allow for portions of a version string "below" a certain level to be dropped.

<!-- Describe the request in detail. What it does and why it's being changed. -->
The `truncate` function, as implemented in this first pass at a PR, returns a new valid version string. The function:

1. Always removes `build` information
2. Removes pre-release information, unless a pre-release type is passed as the `truncation`
3. Zeroes out "lower" components of the semantic version (e.g. if the `truncation` performed is `major`, both `minor` and `patch` are zeroed)

An alternative I considered was returning strings without the valid version guarantee; for example, `truncate('1.2.3', 'minor') === '1.2')` instead of `1.2.0`. This is not what was specified by @isaacs in #48, however, and seemed to be out of place for the rest of the library.

As a result, I also considered naming the function differently. One option I considered was `floor`, which seemed conceptually correct for `major`, `minor`, and `patch`. For `truncation = 'pre*'` however, this did not feel right, as `truncate('1.2.3-rc1+build', 'prerelease') === '1.2.3-rc1'`, but since a) build metadata [_"...MUST be ignored when determining version precedence..."_](https://semver.org/#spec-item-10), and b) there could be a `1.2.3-rc0` that is closer to the "floor", the name didn't seem right for that use case.

Lastly, I considered disallowing the `pre*` versions for the `truncation` argument, and only allowing `major`, `minor`, and `patch`. This, paired with the `floor` naming, was the most attractive alternative to me.

## References
Related to #48
