### PR TITLE
fix: Warn when defaulting to --inc=patch in CLI

### DIFF
--- a/bin/semver.js
+++ b/bin/semver.js
@@ -46,6 +46,7 @@ const main = () => {
       a = a.slice(0, indexOfEqualSign)
       argv.unshift(value)
     }
+
     switch (a) {
       case '-rv': case '-rev': case '--rev': case '--reverse':
         reverse = true
@@ -60,15 +61,10 @@ const main = () => {
         versions.push(argv.shift())
         break
       case '-i': case '--inc': case '--increment':
-        switch (argv[0]) {
-          case 'major': case 'minor': case 'patch': case 'prerelease':
-          case 'premajor': case 'preminor': case 'prepatch':
-          case 'release':
-            inc = argv.shift()
-            break
-          default:
-            inc = 'patch'
-            break
+        if (semver.RELEASE_TYPES.includes(argv[0]) || (argv[0] === 'release')) {
+          inc = { value: argv.shift(), maybeErrantValue: null, option: a }
+        } else {
+          inc = { value: 'patch', maybeErrantValue: argv[0], option: a }
         }
         break
       case '--preid':
@@ -102,6 +98,14 @@ const main = () => {
 
   options = parseOptions({ loose, includePrerelease, rtl })
 
+  if (
+    inc &&
+    versions.includes(inc.maybeErrantValue) &&
+    !semver.valid(inc.maybeErrantValue, options)
+  ) {
+    console.warn(`Invalid value for ${inc.option}; defaulting to 'patch'. This may become a failure in future major versions.`)
+  }
+
   versions = versions.map((v) => {
     return coerce ? (semver.coerce(v, options) || { version: v }).version : v
   }).filter((v) => {
@@ -125,7 +129,7 @@ const main = () => {
   versions
     .sort((a, b) => semver[reverse ? 'rcompare' : 'compare'](a, b, options))
     .map(v => semver.clean(v, options))
-    .map(v => inc ? semver.inc(v, inc, options, identifier, identifierBase) : v)
+    .map(v => inc ? semver.inc(v, inc.value, options, identifier, identifierBase) : v)
     .forEach(v => console.log(v))
 }
 

--- a/tap-snapshots/test/bin/semver.js.test.cjs
+++ b/tap-snapshots/test/bin/semver.js.test.cjs
@@ -303,6 +303,24 @@ Object {
 }
 `
 
+exports[`test/bin/semver.js TAP inc tests > -i invalid 1.0.0 1`] = `
+Object {
+  "code": 0,
+  "err": "Invalid value for -i; defaulting to 'patch'. This may become a failure in future major versions.\\n",
+  "out": "1.0.1\\n",
+  "signal": null,
+}
+`
+
+exports[`test/bin/semver.js TAP inc tests > -i major -i minor 1.0.0 1`] = `
+Object {
+  "code": 0,
+  "err": "",
+  "out": "1.1.0\\n",
+  "signal": null,
+}
+`
+
 exports[`test/bin/semver.js TAP inc tests > -i major 1.0.0 1`] = `
 Object {
   "code": 0,

--- a/test/bin/semver.js
+++ b/test/bin/semver.js
@@ -34,6 +34,8 @@ t.test('inc tests', t => Promise.all([
   ['-i', 'premajor', '1.0.0', '--preid=beta', '-n', 'false'],
   ['-i', '1.2.3'],
   ['-i', 'release', '1.0.0-pre'],
+  ['-i', 'major', '-i', 'minor', '1.0.0'], // last -i "wins"
+  ['-i', 'invalid', '1.0.0'], // invalid -i value, should warn
 ].map(args => t.resolveMatchSnapshot(run(args), args.join(' ')))))
 
 t.test('help output', t => Promise.all([


### PR DESCRIPTION
<!-- What / Why -->
Adds a warning log message to the CLI when the `--increment` option is provided with an invalid increment type. This provides adequate feedback to the user about what is happening, and prepares them for a future where this may no longer be allowed.

<!-- Describe the request in detail. What it does and why it's being changed. -->
In https://github.com/npm/node-semver/issues/108#issuecomment-1111648546, @mklement0 points out (correctly, IMO):

> _Quietly accepting invalid input_ is problematic.

As @lukekarrys points out in [his reply](https://github.com/npm/node-semver/issues/108#issuecomment-1151368027), however, he considers erroring here to be a breaking change. I would tend to agree as this behavior has become part of the contract between the CLI user and the CLI.

The issue is being tracked for the next major version of the CLI, so I offer up that we can safely add the warning indicating that a bad value has been provided, simultaneously preserving the contract, and preparing users for the possibility of a future change. As `console.warn` does not output to `stdout`, existing redirection and/or piping of output _should_ survive this change, thus it will not be breaking. Examples:

    % ./bin/semver.js --inc patchouli 3.2.1 > ./new-version.redirected
    Invalid value for --inc; defaulting to 'patch'. This may become a failure in future major versions.
    % cat ./new-version.redirected
    3.2.2

    % ./bin/semver.js --inc patchouli 3.2.1 | tee ./new-version.teed
    Invalid value for --inc; defaulting to 'patch'. This may become a failure in future major versions.
    3.2.2
    % cat ./new-version.teed 
    3.2.2

The only breakage, then, would occur if we consider `stderr` (or in this case lack thereof) output to _also_ be part of the CLI contract. Example:

    % ./bin/semver.js --inc patchouli 3.2.1 &> ./new-version.err    
    % cat ./new-version.err 
    Invalid value for --inc; defaulting to 'patch'. This may become a failure in future major versions.
    3.2.2

In this case the warning and the new version are both output to `./new-version.err`, and any processing of that output expecting only `3.2.2` might fail.

## Alternative
We could, instead, add a flag to the CLI to opt-in to new behavior re: the `--inc` flag. This could be done in three different ways I can immediately think of:

* `--increment-strict`: an alternate flag used _instead of_ `--increment` that enforces the validity of the argument; downside is that we would then want to remove this in the next release, creating another breaking change
* `--future`: a generic flag that hides all breaking "next version" (currently 8) functionality behind a feature flag, used _in combination with_ `--increment` to enforce the validity of the argument
* `--verbose`: adds the additional "warning" logging added in this PR, with the opportunity for more usage elsewhere

I think the approach in this PR is the simplest and requires the least change in the future, but `--future` and `--verbose` open up other options going forward.

## References
Relates to #108 

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
