### PR TITLE
fix: handle prerelease bounds in subset

### DIFF
--- a/ranges/subset.js
+++ b/ranges/subset.js
@@ -174,7 +174,7 @@ const simpleSubset = (sub, dom, options) => {
         if (higher === c && higher !== gt) {
           return false
         }
-      } else if (gt.operator === '>=' && !satisfies(gt.semver, String(c), options)) {
+      } else if (gt.operator === '>=' && !c.test(gt.semver)) {
         return false
       }
     }
@@ -192,7 +192,7 @@ const simpleSubset = (sub, dom, options) => {
         if (lower === c && lower !== lt) {
           return false
         }
-      } else if (lt.operator === '<=' && !satisfies(lt.semver, String(c), options)) {
+      } else if (lt.operator === '<=' && !c.test(lt.semver)) {
         return false
       }
     }

--- a/test/ranges/subset.js
+++ b/test/ranges/subset.js
@@ -29,6 +29,7 @@ const cases = [
   ['^1.2.3-pre.0', '>=1.0.0', true, { includePrerelease: true }],
   ['^1.2.3-pre.0', '>=1.2.3-pre.0', true],
   ['^1.2.3-pre.0', '>=1.2.3-pre.0', true, { includePrerelease: true }],
+  ['^10.2.0-beta.2', '^10.2.0-beta.1', true],
   ['>1.2.3-pre.0', '>=1.2.3-pre.0', true],
   ['>1.2.3-pre.0', '>1.2.3-pre.0 || 2', true],
   ['1 >1.2.3-pre.0', '>1.2.3-pre.0', true],


### PR DESCRIPTION
## Summary
- Fix `subset()` so prerelease lower and upper bounds are checked against individual comparators without reapplying full range prerelease gating.
- Add coverage for `^10.2.0-beta.2` being a subset of `^10.2.0-beta.1`.

## Tests
- `npx tap test/ranges/subset.js`
- `npm test`
- `git diff --check`

Fixes #757