### PR TITLE
fix: include prereleases in tilde range lower bound with includePrerelease

### DIFF
--- a/classes/range.js
+++ b/classes/range.js
@@ -299,6 +299,10 @@ const replaceTildes = (comp, options) => {
 
 const replaceTilde = (comp, options) => {
   const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE]
+  // if we're including prereleases in the match, then the lower bound is
+  // -0, the lowest possible prerelease value, just like x-ranges and carets.
+  // this keeps `~1.2` equivalent to the `1.2.x` x-range it's documented as.
+  const z = options.includePrerelease ? '-0' : ''
   return comp.replace(r, (_, M, m, p, pr) => {
     debug('tilde', comp, _, M, m, p, pr)
     let ret
@@ -306,10 +310,10 @@ const replaceTilde = (comp, options) => {
     if (isX(M)) {
       ret = ''
     } else if (isX(m)) {
-      ret = `>=${M}.0.0 <${+M + 1}.0.0-0`
+      ret = `>=${M}.0.0${z} <${+M + 1}.0.0-0`
     } else if (isX(p)) {
       // ~1.2 == >=1.2.0 <1.3.0-0
-      ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`
+      ret = `>=${M}.${m}.0${z} <${M}.${+m + 1}.0-0`
     } else if (pr) {
       debug('replaceTilde pr', pr)
       ret = `>=${M}.${m}.${p}-${pr

--- a/test/fixtures/range-include.js
+++ b/test/fixtures/range-include.js
@@ -112,6 +112,13 @@ module.exports = [
   ['2.x', '2.1.0-pre.0', { includePrerelease: true }],
   ['1.1.x', '1.1.0-a', { includePrerelease: true }],
   ['1.1.x', '1.1.1-a', { includePrerelease: true }],
+  // tilde ranges are documented as equivalent to the matching x-range,
+  // so with includePrerelease they must accept the same prereleases. #512
+  ['~1.1', '1.1.0-a', { includePrerelease: true }],
+  ['~1.1.x', '1.1.0-a', { includePrerelease: true }],
+  ['~1.1', '1.1.1-a', { includePrerelease: true }],
+  ['~2', '2.0.0-pre.0', { includePrerelease: true }],
+  ['~2.x', '2.0.0-pre.0', { includePrerelease: true }],
   ['*', '1.0.0-rc1', { includePrerelease: true }],
   ['^1.0.0-0', '1.0.1-rc1', { includePrerelease: true }],
   ['^1.0.0-rc2', '1.0.1-rc1', { includePrerelease: true }],

--- a/test/fixtures/range-parse.js
+++ b/test/fixtures/range-parse.js
@@ -57,6 +57,18 @@ module.exports = [
   ['~> 1', '>=1.0.0 <2.0.0-0'],
   ['~1.0', '>=1.0.0 <1.1.0-0'],
   ['~ 1.0', '>=1.0.0 <1.1.0-0'],
+  // tilde with includePrerelease must lower-bound at -0 just like the
+  // equivalent x-range (e.g. ~1.2 is documented as the same as 1.2.x),
+  // so that prereleases such as 1.2.0-rc match. See #512.
+  ['~1', '>=1.0.0-0 <2.0.0-0', { includePrerelease: true }],
+  ['~1.x', '>=1.0.0-0 <2.0.0-0', { includePrerelease: true }],
+  ['~1.2', '>=1.2.0-0 <1.3.0-0', { includePrerelease: true }],
+  ['~1.2.x', '>=1.2.0-0 <1.3.0-0', { includePrerelease: true }],
+  ['~0.0', '<0.1.0-0', { includePrerelease: true }],
+  // a fully-specified tilde keeps its exact lower bound (matches caret),
+  // and an explicit prerelease is preserved as-is
+  ['~1.2.3', '>=1.2.3 <1.3.0-0', { includePrerelease: true }],
+  ['~1.2.3-beta.4', '>=1.2.3-beta.4 <1.3.0-0', { includePrerelease: true }],
   ['^0', '<1.0.0-0'],
   ['^ 1', '>=1.0.0 <2.0.0-0'],
   ['^0.1', '>=0.1.0 <0.2.0-0'],


### PR DESCRIPTION
Closes #512

## Problem

A tilde range like \`~1.2\` is documented in the README as equivalent to the \`1.2.x\` x-range:

> \`~1.2\` := \`>=1.2.0 <1.(2+1).0\` := \`>=1.2.0 <1.3.0-0\` (**Same as \`1.2.x\`**)

With \`{ includePrerelease: true }\`, both the x-range and the caret operator lower-bound their open forms at \`-0\` (the lowest possible prerelease) so that prereleases like \`1.2.0-rc\` match. The tilde operator did **not**, leaving its lower bound at \`>=1.2.0\`:

```js
const semver = require("semver")
const opts = { includePrerelease: true }

semver.satisfies("1.2.0-rc", "1.2.*", opts)  // true
semver.satisfies("1.2.0-rc", "^1.2.*", opts) // true
semver.satisfies("1.2.0-rc", "~1.2.*", opts) // false  <-- bug

new semver.Range("1.2.*",  opts).range // ">=1.2.0-0 <1.3.0-0"
new semver.Range("^1.2.*", opts).range // ">=1.2.0-0 <2.0.0-0"
new semver.Range("~1.2.*", opts).range // ">=1.2.0 <1.3.0-0"   <-- lower bound missing -0
```

This makes \`~1.2.*\` inconsistent with both its documented x-range equivalent and the caret operator. Reported in #512 (and the same root cause as #510 / #736 discussion around tilde + prerelease).

## Fix

\`replaceCaret\` and \`replaceXRange\` already compute a lower-bound suffix:

```js
const z = options.includePrerelease ? "-0" : ""
```

and apply it to their open forms. \`replaceTilde\` was the only one of the three that did not. This change applies the same suffix to the open tilde forms (\`~1\`, \`~1.x\`, \`~1.2\`, \`~1.2.x\`).

After the fix, \`~1.2.*\` desugars to \`>=1.2.0-0 <1.3.0-0\` — identical to the \`1.2.*\` x-range it is documented to equal.

### Scope / what is intentionally unchanged

- **Default behavior (no \`includePrerelease\`) is untouched** — no \`-0\` is added, so \`~1.2.*\` stays \`>=1.2.0 <1.3.0-0\`.
- **Fully-specified tildes keep their exact lower bound**, matching the caret operator: \`~1.2.3\` with \`includePrerelease\` stays \`>=1.2.3 <1.3.0-0\` (so \`1.2.3-rc\`, which sorts *before* the \`1.2.3\` release, correctly does **not** match — same as \`^1.2.3\`).
- **Explicit-prerelease tildes** (\`~1.2.3-beta\`) are preserved as-is.

## Tests

Added failing-then-passing fixtures:

- \`test/fixtures/range-parse.js\` — desugaring of \`~1\`, \`~1.x\`, \`~1.2\`, \`~1.2.x\`, \`~0.0\` under \`includePrerelease\`, plus \`~1.2.3\` / \`~1.2.3-beta.4\` to lock in that they do *not* change.
- \`test/fixtures/range-include.js\` — \`~1.1\` / \`~1.1.x\` / \`~2\` / \`~2.x\` now satisfy the same prereleases as the equivalent x-ranges.

Full suite (\`npm test\`) and \`eslint\` pass.