### PR TITLE
fix: compare large numeric prerelease ids without precision loss

### DIFF
--- a/internal/identifiers.js
+++ b/internal/identifiers.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* global BigInt */
+
 const numeric = /^[0-9]+$/
 const compareIdentifiers = (a, b) => {
   if (typeof a === 'number' && typeof b === 'number') {
@@ -10,8 +12,10 @@ const compareIdentifiers = (a, b) => {
   const bnum = numeric.test(b)
 
   if (anum && bnum) {
-    a = +a
-    b = +b
+    // compare as BigInt so numeric ids >= MAX_SAFE_INTEGER (kept as strings
+    // to avoid precision loss) are not collapsed by Number coercion
+    a = BigInt(a)
+    b = BigInt(b)
   }
 
   return a === b ? 0

--- a/test/fixtures/comparisons.js
+++ b/test/fixtures/comparisons.js
@@ -35,4 +35,7 @@ module.exports = [
   ['1.2.3-a.b.c.10.d.5', '1.2.3-a.b.c.5.d.100'],
   ['1.2.3-r2', '1.2.3-r100'],
   ['1.2.3-r100', '1.2.3-R2'],
+  // numeric prerelease ids beyond MAX_SAFE_INTEGER (2^53) must keep
+  // full integer precision; Number coercion would collapse them to equal
+  ['1.0.0-9007199254740993', '1.0.0-9007199254740992'],
 ]

--- a/test/internal/identifiers.js
+++ b/test/internal/identifiers.js
@@ -22,3 +22,15 @@ test('rcompareIdentifiers and compareIdentifiers', (t) => {
   t.equal(rcompareIdentifiers(1, 1), 0)
   t.end()
 })
+
+test('compareIdentifiers with numeric ids beyond MAX_SAFE_INTEGER', (t) => {
+  // these arrive as strings because classes/semver.js keeps numeric
+  // prerelease ids >= MAX_SAFE_INTEGER as strings to avoid precision loss.
+  // Number coercion collapses 2^53 and 2^53+1 to the same double, so they
+  // must be compared as full-precision integers.
+  t.equal(compareIdentifiers('9007199254740992', '9007199254740993'), -1)
+  t.equal(rcompareIdentifiers('9007199254740992', '9007199254740993'), 1)
+  t.equal(compareIdentifiers('9007199254740993', '9007199254740992'), 1)
+  t.equal(compareIdentifiers('9007199254740992', '9007199254740992'), 0)
+  t.end()
+})


### PR DESCRIPTION
## Problem

Two valid versions whose prerelease numeric identifiers are >= `2^53` are reported equal and mis-sorted:

```js
semver.compare('1.0.0-9007199254740992', '1.0.0-9007199254740993') // returns 0, should be -1
semver.eq('1.0.0-9007199254740992', '1.0.0-9007199254740993')      // returns true, should be false
semver.gt('1.0.0-9007199254740993', '1.0.0-9007199254740992')      // returns false, should be true
```

Both versions are valid SemVer (there is no magnitude cap on numeric prerelease identifiers in §9), so this violates SemVer 2.0.0 §11.4.1:

> Identifiers consisting of only digits are compared numerically.

`9007199254740992` and `9007199254740993` are distinct integers and must order accordingly.

## Root cause

`classes/semver.js` deliberately keeps numeric prerelease ids `>= MAX_SAFE_INTEGER` as strings to avoid IEEE-754 precision loss in storage:

```js
if (num >= 0 && num < MAX_SAFE_INTEGER) {
  return num
}
return id // kept as string for large ids
```

But `internal/identifiers.js` `compareIdentifiers` re-introduced that loss for any all-digit identifier:

```js
if (anum && bnum) {
  a = +a
  b = +b
}
```

`+'9007199254740992'` and `+'9007199254740993'` both evaluate to the same double (`9007199254740992`), so the comparison sees them as equal.

## Fix

Compare all-digit identifiers with `BigInt` instead of `Number`, preserving full integer precision:

```js
if (anum && bnum) {
  a = BigInt(a)
  b = BigInt(b)
}
```

The already-numberified fast path (`typeof a === 'number' && typeof b === 'number'`, for ids `< MAX_SAFE_INTEGER`) is untouched, and mixed alphanumeric ordering is unchanged.

## Tests

Added a unit case in `test/internal/identifiers.js` for `compareIdentifiers`/`rcompareIdentifiers` with ids beyond `2^53`, and a fixture entry in `test/fixtures/comparisons.js` exercising `compare`/`gt`/`eq` end to end. Both fail on the unpatched code and pass with the fix. Full `npm test` suite (including lint and 100% coverage) is green.
