### PR TITLE
fix: split dotted prerelease identifiers in inc()

### DIFF
--- a/classes/semver.js
+++ b/classes/semver.js
@@ -321,9 +321,21 @@ class SemVer {
         if (identifier) {
           // 1.2.0-beta.1 bumps to 1.2.0-beta.2,
           // 1.2.0-beta.fooblz or 1.2.0-beta bumps to 1.2.0-beta.0
-          let prerelease = [identifier, base]
+          // Split dotted identifiers (e.g. 'x.y') into one element each and
+          // numberify numeric ids, matching how the constructor parses them, so
+          // comparePre() sees exactly one identifier per array element.
+          const identifiers = identifier.split('.').map((id) => {
+            if (/^[0-9]+$/.test(id)) {
+              const num = +id
+              if (num >= 0 && num < MAX_SAFE_INTEGER) {
+                return num
+              }
+            }
+            return id
+          })
+          let prerelease = [...identifiers, base]
           if (identifierBase === false) {
-            prerelease = [identifier]
+            prerelease = identifiers
           }
           if (isPrereleaseIdentifier(this.prerelease, identifier)) {
             const prereleaseBase = this.prerelease[identifier.split('.').length]

--- a/test/fixtures/increments.js
+++ b/test/fixtures/increments.js
@@ -34,6 +34,10 @@ module.exports = [
   ['3.0.0-alpha.beta.5.4', 'prerelease', '3.0.0-alpha.beta.5.5', false, 'alpha.beta'],
   ['3.0.0-alpha.beta.5.4', 'prerelease', '3.0.0-alpha.beta.5.5', false, 'alpha.beta.5'],
   ['3.0.0-alpha.beta.gamma', 'prerelease', '3.0.0-alpha.beta.0', false, 'alpha.beta'],
+  // dotted prerelease identifiers must be split into one element per id
+  ['1.2.3', 'prerelease', '1.2.4-x.y.0', undefined, 'x.y'],
+  ['1.2.3', 'prerelease', '1.2.4-1.2.0', undefined, '1.2'],
+  ['1.2.3', 'prerelease', '1.2.4-9007199254740993.0', undefined, '9007199254740993'],
   ['1.2.3-alpha.9.beta', 'prerelease', '1.2.3-alpha.10.beta'],
   ['1.2.3-alpha.10.beta', 'prerelease', '1.2.3-alpha.11.beta'],
   ['1.2.3-alpha.11.beta', 'prerelease', '1.2.3-alpha.12.beta'],

--- a/test/functions/inc.js
+++ b/test/functions/inc.js
@@ -3,6 +3,8 @@
 const { test } = require('tap')
 const inc = require('../../functions/inc')
 const parse = require('../../functions/parse')
+const compare = require('../../functions/compare')
+const SemVer = require('../../classes/semver')
 const increments = require('../fixtures/increments.js')
 
 test('increment versions test', (t) => {
@@ -42,6 +44,28 @@ test('increment versions test', (t) => {
       t.equal(parsed, null)
     }
   })
+
+  t.end()
+})
+
+test('inc prerelease with a dotted identifier keeps one id per element', (t) => {
+  // Regression: a dotted identifier such as 'x.y' was stored as a single
+  // prerelease element ('x.y'), so comparePre() compared 'x.y' against a plain
+  // identifier and mis-ordered versions. The parsed object then compared
+  // differently from the equivalent version string.
+  const obj = new SemVer('1.2.3-alpha').inc('prerelease', 'x.y')
+  t.equal(obj.version, '1.2.3-x.y.0')
+  t.strictSame(obj.prerelease, ['x', 'y', 0], 'one identifier per array element')
+  t.equal(
+    obj.compare(new SemVer('1.2.3-x.y.1')),
+    compare('1.2.3-x.y.0', '1.2.3-x.y.1'),
+    'object comparison matches string comparison'
+  )
+  t.equal(obj.compare(new SemVer('1.2.3-x.y.1')), -1)
+
+  // numeric ids inside a dotted identifier are numberified exactly like parse()
+  const num = new SemVer('1.2.3').inc('prerelease', '1.2')
+  t.strictSame(num.prerelease, parse(num.version).prerelease)
 
   t.end()
 })


### PR DESCRIPTION
## Summary

`SemVer.prototype.inc('prerelease', identifier)` stores the identifier as a **single** element of the `prerelease` array even when it contains dots. A dotted identifier such as `'x.y'` is stored as `['x.y', 0]` instead of `['x', 'y', 0]`. The formatted version *string* is correct, but the in-memory `prerelease` array is malformed, so `comparePre()` compares a dotted element against a plain identifier and mis-orders versions.

## Reproduction

```js
const { SemVer } = require('semver')
const semver = require('semver')

const a = new SemVer('1.2.3-alpha').inc('prerelease', 'x.y')
a.version            // '1.2.3-x.y.0'   (correct)
a.prerelease         // ['x.y', 0]      <-- should be ['x', 'y', 0]

a.compare(new SemVer('1.2.3-x.y.1'))          //  1   (claims x.y.0 > x.y.1)
semver.compare('1.2.3-x.y.0', '1.2.3-x.y.1')  // -1   (correct)
```

The **same** version compared as a `SemVer` object versus as its string yields **opposite** results. Because `comparePre()` walks the array element-by-element, the malformed `'x.y'` element is compared with `compareIdentifiers('x.y', 'x')` and wins lexically, so `1.2.3-x.y.0` is reported as greater than `1.2.3-x.y.1`.

## Root cause

In `classes/semver.js`, the `pre` case of `inc()` assigns the raw identifier straight into the array:

```js
let prerelease = [identifier, base]   // identifier may be 'x.y'
if (identifierBase === false) {
  prerelease = [identifier]
}
```

The surrounding code already knows identifiers can be dotted — a few lines down it uses `identifier.split('.').length` — but the assignment itself never splits. Every other consumer (`comparePre`, and the constructor) assumes one dot-free identifier per array element.

## Fix

Split the identifier on `.` and numberify numeric ids, exactly as the `SemVer` constructor does when parsing prerelease identifiers, so `comparePre()` sees one identifier per element:

```js
const identifiers = identifier.split('.').map((id) => {
  if (/^[0-9]+$/.test(id)) {
    const num = +id
    if (num >= 0 && num < MAX_SAFE_INTEGER) {
      return num
    }
  }
  return id
})
let prerelease = [...identifiers, base]
if (identifierBase === false) {
  prerelease = identifiers
}
```

After the fix, `inc('1.2.3','prerelease','1.2').prerelease` deep-equals `parse('1.2.4-1.2.0').prerelease` (`[1, 2, 0]`), and object comparison agrees with string comparison. Non-dotted identifiers (`'beta'`, `'dev'`, …) are unaffected.

## Tests

- Adds a dedicated regression test in `test/functions/inc.js` asserting the `prerelease` array shape and that object comparison matches string comparison (the fixture suite only checks the version string, which is why this went unnoticed).
- Adds fixture cases in `test/fixtures/increments.js` for dotted identifiers, including a numeric id and a numeric id ≥ 2^53 (kept as a string, matching the constructor).

Full suite passes with 100% coverage and lint clean.
