### PR TITLE
fix: intersects() misses shared prerelease versions

### DIFF
--- a/classes/range.js
+++ b/classes/range.js
@@ -181,11 +181,7 @@ class Range {
         range.set.some((rangeComparators) => {
           return (
             isSatisfiable(rangeComparators, options) &&
-            thisComparators.every((thisComparator) => {
-              return rangeComparators.every((rangeComparator) => {
-                return thisComparator.intersects(rangeComparator, options)
-              })
-            })
+            comparatorSetsIntersect(thisComparators, rangeComparators, options)
           )
         })
       )
@@ -574,4 +570,45 @@ const testSet = (set, version, options) => {
   }
 
   return true
+}
+
+// The single version pinned by a bare `=x.y.z` comparator in a set, or null.
+const exactVersion = (comparators) => {
+  const exact = comparators.find((c) => c.operator === '' && c.value !== '')
+  return exact ? exact.semver : null
+}
+
+// Do two satisfiable comparator sets share a version?
+// When one set pins an exact version, the sets intersect iff that version
+// satisfies the *whole* other set. Testing the version against the entire set
+// with testSet() (rather than one comparator at a time) preserves prerelease
+// licensing: `1.2.3-alpha` is allowed by `>=1.2.3-alpha <2.0.0-0` because the
+// `>=` sibling licenses it, even though `<2.0.0-0` alone rejects the prerelease.
+// Without an exact pin, fall back to pairwise comparator intersection.
+const comparatorSetsIntersect = (a, b, options) => {
+  options = parseOptions(options)
+
+  // The pairwise check is sufficient but not necessary: it decomposes the sets
+  // into independent comparator pairs and so can miss set-level prerelease
+  // licensing. It only ever under-reports, so a `true` here is authoritative.
+  if (a.every((ac) => b.every((bc) => ac.intersects(bc, options)))) {
+    return true
+  }
+
+  // Recover those missed intersections: when one set pins an exact version, the
+  // two sets share a version iff that version satisfies the *whole* other set.
+  // Testing against the entire set (via testSet) restores prerelease licensing,
+  // e.g. `=1.2.3-alpha` intersects `>=1.2.3-alpha <2.0.0-0` because the `>=`
+  // sibling licenses the prerelease that `<2.0.0-0` alone rejects.
+  const aExact = exactVersion(a)
+  if (aExact) {
+    return testSet(b, aExact, options)
+  }
+
+  const bExact = exactVersion(b)
+  if (bExact) {
+    return testSet(a, bExact, options)
+  }
+
+  return false
 }

--- a/test/fixtures/range-intersection.js
+++ b/test/fixtures/range-intersection.js
@@ -58,4 +58,13 @@ module.exports = [
   ['1.x', '1.3.0 || <1.0.0 >2.0.0', true],
   ['*', '*', true],
   ['x', '', true],
+  // an exact prerelease intersects a caret/tilde range that pins the same
+  // version: the range's `>=` lower bound licenses the prerelease that its
+  // upper bound alone would reject
+  ['^1.2.3-alpha', '=1.2.3-alpha', true],
+  ['~1.2.3-alpha', '1.2.3-alpha', true],
+  ['>=1.2.3-alpha <2.0.0-0', '1.2.3-alpha', true],
+  // but an exact prerelease does NOT intersect a range that never licenses it
+  ['=1.2.3-alpha', '<2.0.0', false],
+  ['=1.2.3-alpha', '=1.2.3-beta', false],
 ]


### PR DESCRIPTION
## Summary

`intersects()` reports two ranges as non-overlapping even when they demonstrably share a prerelease version. It contradicts `satisfies()`: both ranges contain the version, yet `intersects()` says they don't intersect.

## Reproduction

```js
const semver = require('semver')

semver.intersects('^1.2.3-alpha', '=1.2.3-alpha')   // => false  (should be true)
semver.satisfies('1.2.3-alpha', '^1.2.3-alpha')      // => true
semver.satisfies('1.2.3-alpha', '=1.2.3-alpha')      // => true
```

`1.2.3-alpha` satisfies both ranges, so they clearly intersect. The same false negative occurs for:

```js
semver.intersects('~1.2.3-alpha', '=1.2.3-alpha')             // => false (should be true)
semver.intersects('>=1.2.3-alpha <2.0.0-0', '1.2.3-alpha')    // => false (should be true)
```

## Root cause

`Range.intersects` (`classes/range.js`) decomposes the two ranges into independent comparator pairs and requires **every** pair to intersect:

```js
thisComparators.every((thisComparator) =>
  rangeComparators.every((rangeComparator) =>
    thisComparator.intersects(rangeComparator, options)))
```

Prerelease licensing, however, is a **set-level** property. `^1.2.3-alpha` desugars to `>=1.2.3-alpha <2.0.0-0`; the `>=1.2.3-alpha` comparator is what licenses the prerelease `1.2.3-alpha`. When the exact comparator `=1.2.3-alpha` is paired with `<2.0.0-0` in isolation, `Comparator.intersects` evaluates `new Range('<2.0.0-0').test('1.2.3-alpha')`, which is `false` (a single-comparator range applies the prerelease-tuple exclusion). The sibling `>=1.2.3-alpha` that would license the prerelease is not visible in that pair, so the whole intersection is wrongly reported empty.

## Fix

The pairwise check only ever **under-reports**, so it stays as a *sufficient* condition. When it fails, recover the missed cases: if one set pins an exact version (a bare `=x.y.z`), the two sets share a version iff that version satisfies the **whole** other set — tested with `testSet`, which applies prerelease licensing across all of a set's comparators.

```js
const comparatorSetsIntersect = (a, b, options) => {
  options = parseOptions(options)
  if (a.every((ac) => b.every((bc) => ac.intersects(bc, options)))) {
    return true
  }
  const aExact = exactVersion(a)
  if (aExact) {
    return testSet(b, aExact, options)
  }
  const bExact = exactVersion(b)
  if (bExact) {
    return testSet(a, bExact, options)
  }
  return false
}
```

This is deliberately conservative:

- Ranges with no exact pin fall straight through to the original pairwise result — **unchanged**.
- The `*` / `ANY` short-circuit is **unchanged**.
- A version differential against unmodified `7.8.5` over a matrix of range pairs (with and without `includePrerelease`) shows the fix flips **only** the genuine false negatives to `true` (each backed by a concrete shared version) and changes nothing else.
- Soundness holds: across the same matrix, every `intersects(...) === false` still has no version satisfying both ranges.

## Tests

Adds fixture cases in `test/fixtures/range-intersection.js` (exercised in both argument orderings) for the fixed cases and for the still-correct negatives (e.g. `=1.2.3-alpha` vs `<2.0.0`, which has no licensing sibling and must remain `false`). Full suite passes with 100% coverage and lint clean.
