### PR TITLE
fix: intersects() false-negative for <0.0.0-<prerelease> comparators

### DIFF
--- a/classes/comparator.js
+++ b/classes/comparator.js
@@ -100,8 +100,9 @@ class Comparator {
       (this.value === '<0.0.0-0' || comp.value === '<0.0.0-0')) {
       return false
     }
+    const isNullSet = v => v === '<0.0.0' || v === '<0.0.0-0'
     if (!options.includePrerelease &&
-      (this.value.startsWith('<0.0.0') || comp.value.startsWith('<0.0.0'))) {
+      (isNullSet(this.value) || isNullSet(comp.value))) {
       return false
     }
 

--- a/test/fixtures/comparator-intersection.js
+++ b/test/fixtures/comparator-intersection.js
@@ -41,4 +41,13 @@ module.exports = [
   ['<0.1.0', '<0.0.0-0', false],
   ['<0.0.0-0', '<0.1.0', false, true],
   ['<0.1.0', '<0.0.0-0', false, true],
+  // A `<0.0.0-<id>` comparator (with a non-minimal prerelease) is NOT the empty
+  // set: it matches prereleases below `<id>` such as `0.0.0-0`, so it can
+  // intersect other ranges. Only `<0.0.0` and `<0.0.0-0` match nothing. See #521.
+  ['<0.0.0-rc.1', '>=0.0.0-alpha.0', true],
+  ['<0.0.0-rc.1', '>0.0.0-alpha.0', true],
+  ['<0.0.0-beta', '>=0.0.0-alpha', true],
+  ['<0.0.0-alpha', '<0.0.0-rc.1', true],
+  ['<0.0.0', '>=0.0.0-alpha.0', false],
+  ['<0.0.0', '>0.0.0-alpha.0', false],
 ]

--- a/test/fixtures/range-intersection.js
+++ b/test/fixtures/range-intersection.js
@@ -58,4 +58,10 @@ module.exports = [
   ['1.x', '1.3.0 || <1.0.0 >2.0.0', true],
   ['*', '*', true],
   ['x', '', true],
+  // `<0.0.0-<id>` matches prereleases below `<id>`, so it can intersect ranges
+  // that also admit those prereleases; only `<0.0.0`/`<0.0.0-0` are empty. #521
+  ['<0.0.0-rc.1', '~0.0.0-alpha.0', true],
+  ['<0.0.0-rc.1 <=0.3.2-0', '~0.0.0-alpha.0 || 1', true],
+  ['<0.0.0', '0.x', false],
+  ['<0.0.0', '>=0.0.0-alpha.0', false],
 ]

--- a/test/ranges/intersects.js
+++ b/test/ranges/intersects.js
@@ -2,6 +2,7 @@
 
 const { test } = require('tap')
 const intersects = require('../../ranges/intersects')
+const satisfies = require('../../functions/satisfies')
 const Range = require('../../classes/range')
 const Comparator = require('../../classes/comparator')
 const comparatorIntersection = require('../fixtures/comparator-intersection.js')
@@ -56,5 +57,53 @@ test('missing comparator parameter in intersect comparators', (t) => {
     new Comparator('>1.0.0').intersects()
   }, new TypeError('a Comparator is required'),
   'throws type error')
+  t.end()
+})
+
+// Differential oracle: if a concrete version satisfies BOTH ranges, then the
+// ranges MUST intersect. This densely samples the near-zero / prerelease space
+// where `<0.0.0-<id>` comparators live, guarding against the over-broad
+// `startsWith('<0.0.0')` empty-range check that wrongly treated e.g.
+// `<0.0.0-rc.1` (which matches `0.0.0-0`, `0.0.0-alpha`, ...) as matching
+// nothing, producing false negatives from `intersects`.
+test('intersects agrees with pointwise satisfaction', t => {
+  const nums = [0, 1, 2]
+  const pres = ['', '-0', '-alpha', '-alpha.0', '-alpha.1', '-beta', '-rc.1', '-rc.2']
+  const grid = []
+  for (const a of nums) {
+    for (const b of nums) {
+      for (const c of nums) {
+        for (const p of pres) {
+          grid.push(`${a}.${b}.${c}${p}`)
+        }
+      }
+    }
+  }
+
+  const anchors = ['0.0.0', '0.0.0-0', '0.0.0-alpha', '0.0.0-rc.1',
+    '0.1.0-alpha', '1.0.0-alpha', '1.0.0']
+  const comparators = []
+  for (const op of ['<', '<=', '>', '>=', '']) {
+    for (const v of anchors) {
+      comparators.push(`${op}${v}`)
+    }
+  }
+
+  let witnessBacked = 0
+  for (const opts of [{}, { includePrerelease: true }]) {
+    for (const a of comparators) {
+      for (const b of comparators) {
+        const witness = grid.find(v => satisfies(v, a, opts) && satisfies(v, b, opts))
+        if (witness === undefined) {
+          continue
+        }
+        witnessBacked++
+        const label = `${JSON.stringify(opts)}: ${witness} satisfies both`
+        t.equal(intersects(a, b, opts), true, `${a} ∩ ${b} (${label})`)
+        t.equal(intersects(b, a, opts), true, `${b} ∩ ${a} symmetry (${label})`)
+      }
+    }
+  }
+  t.ok(witnessBacked > 100, `exercised ${witnessBacked} witness-backed pairs`)
   t.end()
 })


### PR DESCRIPTION
### Bug

`intersects()` returns `false` for two ranges that demonstrably share a version, contradicting `satisfies()`:

```js
semver.intersects('<0.0.0-rc.1', '>=0.0.0-alpha.0')  // => false  (WRONG)
semver.satisfies('0.0.0-alpha.0', '<0.0.0-rc.1')      // => true
semver.satisfies('0.0.0-alpha.0', '>=0.0.0-alpha.0')  // => true
```

`0.0.0-alpha.0` satisfies both ranges, so they intersect. The tell that it is specific to the `0.0.0` tuple: `intersects('<1.0.0-rc', '>=1.0.0-alpha')` is correctly `true`.

### Root cause

In `Comparator.intersects` (`classes/comparator.js`), the default-mode "this comparator matches nothing" guard uses `startsWith('<0.0.0')`:

```js
if (!options.includePrerelease &&
  (this.value.startsWith('<0.0.0') || comp.value.startsWith('<0.0.0'))) {
  return false
}
```

But the only genuinely-empty comparator values are `<0.0.0` and the codebase's own null-set sentinel `<0.0.0-0` (see `range.js`: `isNullSet = c => c.value === '<0.0.0-0'`). `<0.0.0-rc.1`, `<0.0.0-alpha`, etc. are **not** empty — they match prereleases below their own id (`0.0.0-0`, `0.0.0-alpha`, ...). `startsWith` over-matches them and short-circuits `intersects` to `false`.

### Fix

Only treat the two real null-set values as empty; everything else falls through to the normal opposite-direction logic. The `includePrerelease` branch above (already `=== '<0.0.0-0'`) is untouched.

### Tests

`test/ranges/intersects.js` gains a property-oracle block that builds a near-zero + prerelease version grid × a comparator matrix and asserts, for every pair with a real shared witness version, that `intersects` is `true` in both directions (1,289 witness-backed pairs). Fixture rows are added to `comparator-intersection.js` (incl. the `<0.0.0` guards that must stay `false`) and `range-intersection.js`. Full suite passes; lint clean.

### Relation to #884

This is independent of open #884. #884 patches set-level decomposition in `range.js` for cases where one set pins an exact `=x.y.z`; it does not touch `comparator.js`. Cross-applied: with #884 alone my `<0.0.0-rc.1` case stays `false`; with this fix alone #884's `^1.2.3-alpha` case stays `false`. If #884 lands first, the only overlap is the appended rows in `test/fixtures/range-intersection.js` (a trivial append-only rebase).