### PR TITLE
docs: clarify includePrerelease hyphen ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,11 @@ provided tuple parts.
 * `1.2.3 - 2.3` := `>=1.2.3 <2.4.0-0`
 * `1.2.3 - 2` := `>=1.2.3 <3.0.0-0`
 
+When `includePrerelease` is set, partial versions in hyphen ranges
+include prereleases at the expanded lower bound. For example,
+`1 - 2` is treated as `>=1.0.0-0 <3.0.0-0`, so `1.0.0-pre`
+satisfies the range with `includePrerelease`.
+
 #### X-Ranges `1.2.x` `1.X` `1.2.*` `*`
 
 Any of `X`, `x`, or `*` may be used to "stand in" for one of the
@@ -677,4 +682,3 @@ The following modules are available:
 * `require('semver/ranges/subset')`
 * `require('semver/ranges/to-comparators')`
 * `require('semver/ranges/valid')`
-


### PR DESCRIPTION
## Summary

- clarify how `includePrerelease` affects partial hyphen ranges
- add the concrete `1 - 2` expansion example discussed in #799

## Verification

- `./node_modules/.bin/tap test/classes/range.js test/functions/satisfies.js`
- `npm test`
- `git diff --check`

Refs #799.
