### PR TITLE
fix: minVersion returns the true minimum for `>` in includePrerelease mode

### DIFF
--- a/ranges/min-version.js
+++ b/ranges/min-version.js
@@ -29,6 +29,12 @@ const minVersion = (range, loose) => {
         case '>':
           if (compver.prerelease.length === 0) {
             compver.patch++
+            // in includePrerelease mode the next patch's lowest prerelease
+            // (e.g. 1.0.1-0) also satisfies `>1.0.0` and is lower than 1.0.1,
+            // so it is the true minimum -- matching the prerelease `>` case below
+            if (range.includePrerelease) {
+              compver.prerelease.push(0)
+            }
           } else {
             compver.prerelease.push(0)
           }

--- a/test/ranges/min-version.js
+++ b/test/ranges/min-version.js
@@ -64,6 +64,11 @@ test('minimum version in range tests', (t) => {
     ['>2 || >1.0.0-0', '1.0.0-0.0'],
     ['>2 || >1.0.0-beta', '1.0.0-beta.0'],
 
+    // includePrerelease: the lowest prerelease of the next version is the true
+    // minimum for a `>` bound (and lower than the plain next version)
+    ['>1.0.0', '1.0.1-0', { includePrerelease: true }],
+    ['>2 || >1.0.0', '1.0.1-0', { includePrerelease: true }],
+
     // Impossible range
     ['>4 <3', null],
   ].forEach((tuple) => {


### PR DESCRIPTION
## What

`minVersion` returns "the lowest version that can possibly match the given range", but for a `>X.Y.Z` bound in `includePrerelease` mode it skips the lowest prerelease of the next version:

```js
semver.minVersion('>1.0.0', { includePrerelease: true }) // 1.0.1
```

`1.0.1-0` also satisfies `>1.0.0` under `includePrerelease` and is lower than `1.0.1`:

```js
semver.satisfies('1.0.1-0', '>1.0.0', { includePrerelease: true }) // true
semver.lt('1.0.1-0', '1.0.1')                                      // true
```

so `1.0.1` is not the minimum.

## Root cause

For a `>` comparator that already carries a prerelease, `minVersion` appends `.0` to reach the lowest prerelease (`>1.0.0-0` → `1.0.0-0.0`). The plain `>X.Y.Z` branch only did `patch++` and never considered prereleases — even when `includePrerelease` puts them in scope.

## Fix

After bumping the patch for a prerelease-less `>` bound, append the `-0` prerelease when the range includes prereleases, so `>1.0.0` yields `1.0.1-0`. Default (non-includePrerelease) mode is unchanged — `>1.0.0` still yields `1.0.1`.

## Tests

Added `['>1.0.0', '1.0.1-0', { includePrerelease: true }]` and `['>2 || >1.0.0', '1.0.1-0', { includePrerelease: true }]`. Both fail on `main` and pass with the fix; the existing default-mode case `['>1.0.0', '1.0.1']` is untouched and the ranges suite stays green.
