### PR TITLE
perf: avoid reordering the range cache on every hit

### DIFF
--- a/internal/lrucache.js
+++ b/internal/lrucache.js
@@ -1,40 +1,46 @@
 'use strict'
 
+// Two generations, with no reordering on read. A hit in the old generation is
+// promoted back into the live one. When the live generation fills up it becomes
+// the old one and the previous old generation is dropped, so at most 2 * max
+// entries are retained.
 class LRUCache {
   constructor () {
     this.max = 1000
     this.map = new Map()
+    this.old = new Map()
   }
 
   get (key) {
     const value = this.map.get(key)
-    if (value === undefined) {
-      return undefined
-    } else {
-      // Remove the key from the map and add it to the end
-      this.map.delete(key)
-      this.map.set(key, value)
+    if (value !== undefined) {
       return value
     }
+    const stale = this.old.get(key)
+    if (stale !== undefined) {
+      this.set(key, stale)
+      return stale
+    }
+    return undefined
   }
 
   delete (key) {
-    return this.map.delete(key)
+    const inMap = this.map.delete(key)
+    const inOld = this.old.delete(key)
+    return inMap || inOld
   }
 
   set (key, value) {
-    const deleted = this.delete(key)
-
-    if (!deleted && value !== undefined) {
-      // If cache is full, delete the least recently used item
-      if (this.map.size >= this.max) {
-        const firstKey = this.map.keys().next().value
-        this.delete(firstKey)
-      }
-
-      this.map.set(key, value)
+    if (value === undefined) {
+      return this
     }
 
+    if (!this.map.has(key) && this.map.size >= this.max) {
+      this.old = this.map
+      this.map = new Map()
+    }
+
+    this.map.set(key, value)
     return this
   }
 }

--- a/test/internal/lrucache.js
+++ b/test/internal/lrucache.js
@@ -14,8 +14,57 @@ test('basic cache operation', t => {
     t.equal(c.get(i), i)
   }
   c.set(1001, 1001)
-  // lru item should be gone
+  t.equal(c.get(1001), 1001)
+  // setting undefined is a no-op and does not clobber an existing value
+  t.equal(c.set(42, undefined), c)
+  t.equal(c.get(42), 42)
+  t.equal(c.get('not-in-the-cache'), undefined)
+  t.end()
+})
+
+test('delete removes the key from both generations', t => {
+  const c = new LRUCache()
+  const max = 1000
+
+  for (let i = 0; i < max; i++) {
+    c.set(i, i)
+  }
+  // fills the live generation, demoting everything above into the old one
+  c.set('rotate', 1)
+  c.set(7, 'live')
+
+  t.equal(c.delete(7), true)
+  t.equal(c.get(7), undefined)
+  t.equal(c.delete(7), false)
+  t.end()
+})
+
+test('entries are evicted once the cache is full', t => {
+  const c = new LRUCache()
+
+  for (let i = 0; i < 10 * c.max; i++) {
+    c.set(i, i)
+  }
   t.equal(c.get(0), undefined)
-  c.set(42, undefined)
+  t.ok(c.map.size + c.old.size <= 2 * c.max)
+  t.end()
+})
+
+test('promoting from the old generation stays within the bound', t => {
+  const c = new LRUCache()
+  const max = c.max
+
+  for (let i = 0; i < max; i++) {
+    c.set(`a${i}`, i)
+  }
+  c.set('rotate', 1)
+  for (let i = 0; i < max - 2; i++) {
+    c.set(`b${i}`, i)
+  }
+  for (let i = 0; i < max; i++) {
+    c.get(`a${i}`)
+  }
+
+  t.ok(c.map.size + c.old.size <= 2 * max)
   t.end()
 })


### PR DESCRIPTION
`Range.parseRange` is memoized in `internal/lrucache.js`. On every cache **hit**, the current implementation does `map.delete(key)` + `map.set(key, value)` to move the entry to the end of the insertion order. That reorder is pure overhead on a hot path.

This replaces the single map with two generations and drops the reorder. A hit in the old generation is promoted back into the live one; when the live generation fills, it becomes the old one and the previous old generation is dropped.

`parseRange` is deterministic, and the memo key already covers the range string plus both flags that affect parsing, so the eviction policy cannot change any result — only whether a given call re-parses. I verified that directly: 43,200 cases across `satisfies` / `validRange` / `maxSatisfying` / `minSatisfying` / `minVersion` / `intersects` / `subset`, each under `{}`, `{loose}`, `{includePrerelease}`, and both, produce byte-identical output before and after.

Benchmarks on node v24.8.0, one variant per process, best-of-5 within a process, min across 5 rounds. Corpus is every distinct range and version in the eslint / express / lodash / react / typescript / webpack packuments (1,965 ranges, 7,947 versions):

| shape | speedup |
| --- | --- |
| `benchmarks/bench-satisfies.js` as written | 1.72x |
| 400 ranges x 300 versions | 2.05x |
| 5 ranges x 7,900 versions | 3.52x |
| 1,960-range dependency tree | 1.09x |
| hot set of 900 ranges + cold stream | 1.10x |
| `maxSatisfying` over 7,900 versions | 1.01x |

No shape I tried is slower than stock. The retained ceiling goes from 1,000 entries (~0.78 MB) to 2,000 (~1.88 MB), measured by flooding 80,000 distinct ranges and sampling retained heap.

Two things worth flagging for review:

- `test/internal/lrucache.js` asserted that the oldest key is gone immediately after the first over-cap insert, which is specific to strict LRU. I replaced it with tests for the properties the cache actually needs: value round-trip, `set(key, undefined)` as a no-op, `delete` clearing both generations, eviction under flood, and the `2 * max` bound holding under promotion.
- The class is no longer an LRU. I left the name and filename alone to keep the diff small, but happy to rename if you'd prefer.

For context on why the second generation is there rather than just deleting the reorder: dropping the reorder alone turns the cache into FIFO, which evicts a hot set that strict LRU would pin. On a hot set of 900 ranges just under the 1,000 cap, that regresses to 0.40x. The second generation is what avoids that.
