### PR TITLE
docs: document accepted range whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,15 +389,15 @@ for the benefit of parser authors:
 
 ```bnf
 range-set  ::= range ( logical-or range ) *
-logical-or ::= ( ' ' ) * '||' ( ' ' ) *
-range      ::= hyphen | simple ( ' ' simple ) * | ''
+logical-or ::= wsp '||' wsp
+range      ::= hyphen | simple ( wsp1 simple ) * | ''
 hyphen     ::= partial ' - ' partial
 simple     ::= primitive | partial | tilde | caret
 primitive  ::= ( '<' | '>' | '>=' | '<=' | '=' ) partial
-partial    ::= xr ( '.' xr ( '.' xr qualifier ? )? )?
+partial    ::= wsp xr ( '.' xr ( '.' xr qualifier ? )? )?
 xr         ::= 'x' | 'X' | '*' | nr
 nr         ::= '0' | ['1'-'9'] ( ['0'-'9'] ) *
-tilde      ::= '~' partial
+tilde      ::= '~' wsp ( '>' ) ? partial
 caret      ::= '^' partial
 qualifier  ::= ( '-' pre )? ( '+' build )?
 pre        ::= prepart ( '.' prepart ) *
@@ -405,6 +405,8 @@ prepart    ::= nr | alphanumid
 build      ::= buildid ( '.' buildid ) *
 alphanumid ::= ( ['0'-'9'] ) * [-A-Za-z] [-0-9A-Za-z] *
 buildid    ::= [-0-9A-Za-z]+
+wsp        ::= ( ' ' ) *
+wsp1       ::= ' ' wsp
 ```
 
 Note: Prerelease identifiers (`pre`) use `nr` for numeric parts, which
@@ -677,4 +679,3 @@ The following modules are available:
 * `require('semver/ranges/subset')`
 * `require('semver/ranges/to-comparators')`
 * `require('semver/ranges/valid')`
-

--- a/range.bnf
+++ b/range.bnf
@@ -1,13 +1,13 @@
 range-set  ::= range ( logical-or range ) *
-logical-or ::= ( ' ' ) * '||' ( ' ' ) *
-range      ::= hyphen | simple ( ' ' simple ) * | ''
+logical-or ::= wsp '||' wsp
+range      ::= hyphen | simple ( wsp1 simple ) * | ''
 hyphen     ::= partial ' - ' partial
 simple     ::= primitive | partial | tilde | caret
 primitive  ::= ( '<' | '>' | '>=' | '<=' | '=' ) partial
-partial    ::= xr ( '.' xr ( '.' xr qualifier ? )? )?
+partial    ::= wsp xr ( '.' xr ( '.' xr qualifier ? )? )?
 xr         ::= 'x' | 'X' | '*' | nr
 nr         ::= '0' | [1-9] ( [0-9] ) *
-tilde      ::= '~' partial
+tilde      ::= '~' wsp ( '>' ) ? partial
 caret      ::= '^' partial
 qualifier  ::= ( '-' pre )? ( '+' build )?
 pre        ::= prepart ( '.' prepart ) *
@@ -15,3 +15,5 @@ prepart    ::= nr | alphanumid
 build      ::= buildid ( '.' buildid ) *
 alphanumid ::= ( [0-9] ) * [A-Za-z-] [-0-9A-Za-z] *
 buildid    ::= [-0-9A-Za-z]+
+wsp        ::= ( ' ' ) *
+wsp1       ::= ' ' wsp


### PR DESCRIPTION
## Summary

- document whitespace accepted before partial versions in the range BNF
- document the accepted `~>` tilde form
- allow one or more spaces between simple range expressions in the grammar

The README and standalone `range.bnf` now describe the same forms already accepted by the strict parser. This does not change runtime behavior.

Fixes #392.

## Verification

- strict-mode smoke checks for `>= 1.2.3 < 1.6.0`, `^ 1.2.3 || ^ 2.4.6`, `~ > 1.2.3`, and `~> 1.2.3`
- `./node_modules/.bin/tap test/ranges/valid.js`
- `npm test`
- `git diff --check`
